### PR TITLE
Ensure package.attribute column is empty array, not null

### DIFF
--- a/pkg/models/dbTable/packageTable_test.go
+++ b/pkg/models/dbTable/packageTable_test.go
@@ -18,29 +18,35 @@ func truncate(t *testing.T, db *sql.DB, orgID int, table string) {
 }
 
 func TestPackageAttributeValueAndScan(t *testing.T) {
-	tests := map[string]packageInfo.PackageAttributes{
-		"non-empty": {
-			{Key: "subtype",
-				Fixed:    false,
-				Value:    "Image",
-				Hidden:   true,
-				Category: "Pennsieve",
-				DataType: "string"},
-			{Key: "icon",
-				Fixed:    false,
-				Value:    "Microscope",
-				Hidden:   true,
-				Category: "Pennsieve",
-				DataType: "string"}},
-		"nil":   nil,
-		"empty": {},
+	emptyAttrs := packageInfo.PackageAttributes{}
+	nonEmptyAttrs := packageInfo.PackageAttributes{
+		{Key: "subtype",
+			Fixed:    false,
+			Value:    "Image",
+			Hidden:   true,
+			Category: "Pennsieve",
+			DataType: "string"},
+		{Key: "icon",
+			Fixed:    false,
+			Value:    "Microscope",
+			Hidden:   true,
+			Category: "Pennsieve",
+			DataType: "string"}}
+	tests := map[string]struct {
+		input    packageInfo.PackageAttributes
+		expected packageInfo.PackageAttributes
+	}{
+		"non-empty": {nonEmptyAttrs, nonEmptyAttrs},
+		// If an insert contains a nil PackageAttributes we want to put empty json array in DB
+		"nil":   {nil, emptyAttrs},
+		"empty": {emptyAttrs, emptyAttrs},
 	}
 
 	orgId := 2
 	db, err := core.ConnectENVWithOrg(orgId)
 	assert.NoError(t, err)
 	defer db.Close()
-	for name, expectedAttributes := range tests {
+	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
 			p := Package{
 				Name:         "image.jpg",
@@ -49,7 +55,7 @@ func TestPackageAttributeValueAndScan(t *testing.T) {
 				NodeId:       "N:package:1234",
 				DatasetId:    1,
 				OwnerId:      1,
-				Attributes:   expectedAttributes}
+				Attributes:   data.input}
 			insert := fmt.Sprintf(
 				"INSERT INTO \"%d\".packages (name, type, state, node_id, dataset_id, owner_id, attributes) VALUES ($1, $2, $3, $4, $5, $6, $7)",
 				orgId)
@@ -82,7 +88,7 @@ func TestPackageAttributeValueAndScan(t *testing.T) {
 			assert.Equal(t, p.NodeId, actual.NodeId)
 			assert.Equal(t, p.DatasetId, actual.DatasetId)
 			assert.Equal(t, p.OwnerId, actual.OwnerId)
-			assert.Equal(t, p.Attributes, actual.Attributes)
+			assert.Equal(t, data.expected, actual.Attributes)
 		})
 	}
 

--- a/pkg/models/packageInfo/packageAttributes.go
+++ b/pkg/models/packageInfo/packageAttributes.go
@@ -22,6 +22,9 @@ type PackageAttributes []PackageAttribute
 // a non-pointer receiver and Scan() has a pointer receiver.
 
 func (a PackageAttributes) Value() (driver.Value, error) {
+	if a == nil {
+		return json.Marshal(PackageAttributes{})
+	}
 	return json.Marshal(a)
 }
 


### PR DESCRIPTION
Fixes issue where a missing `Package.Attributes` field was being inserted into the DB as null. Code elsewhere is expecting the DB value to be an empty JSON array in this case. This PR has `PackageAttributes`' `Valuer` implementation marshal an empty array if the receiver is nil.