### PR TITLE
Fix for dbTable.Dataset

### DIFF
--- a/pkg/models/dbTable/datasetTable.go
+++ b/pkg/models/dbTable/datasetTable.go
@@ -2,12 +2,34 @@ package dbTable
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/pennsieve/pennsieve-go-core/pkg/core"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
 	"log"
 	"time"
 )
+
+type Tags []string
+
+func (t Tags) Value() (driver.Value, error) {
+	return (*pq.StringArray)(&t).Value()
+}
+
+func (t *Tags) Scan(src any) error {
+	return (*pq.StringArray)(t).Scan(src)
+}
+
+type Contributors []string
+
+func (c Contributors) Value() (driver.Value, error) {
+	return (*pq.StringArray)(&c).Value()
+}
+
+func (c *Contributors) Scan(src any) error {
+	return (*pq.StringArray)(c).Scan(src)
+}
 
 type Dataset struct {
 	Id                           int64          `json:"id"`
@@ -22,9 +44,9 @@ type Dataset struct {
 	Role                         sql.NullString `json:"role"`
 	Status                       string         `json:"status"`
 	AutomaticallyProcessPackages bool           `json:"automatically_process_packages"`
-	Licence                      sql.NullString `json:"licence"`
-	Tags                         []string       `json:"tags"`
-	Contributors                 []string       `json:"contributors"`
+	License                      sql.NullString `json:"license"`
+	Tags                         Tags           `json:"tags"`
+	Contributors                 Contributors   `json:"contributors"`
 	BannerId                     uuid.UUID      `json:"banner_id"`
 	ReadmeId                     uuid.UUID      `json:"readme_id"`
 	StatusId                     int32          `json:"status_id"`

--- a/pkg/models/dbTable/datasetTable_test.go
+++ b/pkg/models/dbTable/datasetTable_test.go
@@ -1,0 +1,65 @@
+package dbTable
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/core"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDatasetsInsertSelect(t *testing.T) {
+	orgId := 3
+	db, err := core.ConnectENVWithOrg(3)
+	defer func() {
+		if db != nil {
+			assert.NoError(t, db.Close())
+		}
+	}()
+	assert.NoErrorf(t, err, "could not open DB")
+
+	input := Dataset{
+		Id:           1,
+		Name:         "Test Dataset",
+		State:        "READY",
+		Description:  sql.NullString{},
+		NodeId:       sql.NullString{String: "N:dataset:1234", Valid: true},
+		Role:         sql.NullString{String: "editor", Valid: true},
+		Tags:         Tags{"test", "sql"},
+		Contributors: Contributors{},
+		StatusId:     int32(1),
+	}
+	_, err = db.Exec("INSERT INTO datasets (id, name, state, description, node_id, role, tags, contributors, status_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)", input.Id, input.Name, input.State, input.Description, input.NodeId, input.Role, input.Tags, input.Contributors, input.StatusId)
+	defer truncate(t, db, orgId, "datasets")
+	if assert.NoError(t, err) {
+
+		countStmt := fmt.Sprintf("SELECT COUNT(*) FROM datasets")
+		var count int
+		assert.NoError(t, db.QueryRow(countStmt).Scan(&count))
+		assert.Equal(t, 1, count)
+
+		var actual Dataset
+		err = db.QueryRow("SELECT id, name, state, description, node_id, role, tags, contributors, status_id FROM datasets").Scan(
+			&actual.Id,
+			&actual.Name,
+			&actual.State,
+			&actual.Description,
+			&actual.NodeId,
+			&actual.Role,
+			&actual.Tags,
+			&actual.Contributors,
+			&actual.StatusId)
+		if assert.NoError(t, err) {
+			assert.Equal(t, input.Name, actual.Name)
+			assert.Equal(t, input.State, actual.State)
+			assert.Equal(t, input.NodeId, actual.NodeId)
+			assert.Equal(t, input.Role, actual.Role)
+			assert.Equal(t, input.StatusId, actual.StatusId)
+
+			assert.Equal(t, input.Tags, actual.Tags)
+			assert.Equal(t, input.Contributors, actual.Contributors)
+			assert.False(t, actual.Description.Valid)
+		}
+	}
+
+}

--- a/pkg/upload/manifest_test.go
+++ b/pkg/upload/manifest_test.go
@@ -331,13 +331,23 @@ func testAddFiles(t *testing.T, ms *ManifestSession) {
 		},
 	}
 
+	testFileUploadIds := map[string]any{}
+	for _, f := range testFileDTOs {
+		testFileUploadIds[f.UploadID] = nil
+	}
+
 	// Adding files to upload
 	manifestId := "1111"
 	result := ms.AddFiles(manifestId, testFileDTOs, nil)
 
 	// Checking returned status
 	assert.Equal(t, manifestFile.Unknown, result.FileStatus[0].Status)
-	assert.Equal(t, testFileDTOs[0].UploadID, result.FileStatus[0].UploadId)
+
+	resultUploadIds := map[string]any{}
+	for _, f := range result.FileStatus {
+		resultUploadIds[f.UploadId] = nil
+	}
+	assert.Equal(t, testFileUploadIds, resultUploadIds)
 
 }
 


### PR DESCRIPTION
Fixes typos in `dbTable.Dataset.License` 

Adds Value() and Scan() methods for `dbTable.Dataset.Tags` and `.Contributors` for usability. (Won't have to wrap values in `pq.Array()` in every DB Exec/Query call.)
