### PR TITLE
Implement Create Dataset

### DIFF
--- a/pkg/models/dataset/state/models.go
+++ b/pkg/models/dataset/state/models.go
@@ -1,0 +1,8 @@
+package state
+
+type stateType string
+
+const (
+	READY    stateType = "READY"
+	DELETING           = "DELETING"
+)

--- a/pkg/models/nodeId/nodeId.go
+++ b/pkg/models/nodeId/nodeId.go
@@ -1,0 +1,38 @@
+package nodeId
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+)
+
+type NodeType int64
+
+const (
+	UserCode NodeType = iota
+	OrganizationCode
+	TeamCode
+	FileCode
+	PackageCode
+	CollectionCode
+	DataSetCode
+	ChannelCode
+	DataCanvasCode
+	FolderCode
+)
+
+var NodeCodeMap = map[NodeType]string{
+	UserCode:         "user",
+	OrganizationCode: "organization",
+	TeamCode:         "team",
+	FileCode:         "file",
+	PackageCode:      "package",
+	CollectionCode:   "collection",
+	DataSetCode:      "dataset",
+	ChannelCode:      "channel",
+	DataCanvasCode:   "canvas",
+	FolderCode:       "folder",
+}
+
+func NodeId(nodeType NodeType) string {
+	return fmt.Sprintf("N:%s:%s", NodeCodeMap[nodeType], uuid.NewString())
+}

--- a/pkg/models/pgdb/contributorsTable.go
+++ b/pkg/models/pgdb/contributorsTable.go
@@ -1,0 +1,19 @@
+package pgdb
+
+import (
+	"database/sql"
+	"time"
+)
+
+type Contributor struct {
+	Id            int64          `json:"id"`
+	FirstName     string         `json:"first_name"`
+	LastName      string         `json:"last_name"`
+	Email         string         `json:"email"`
+	Orcid         sql.NullString `json:"orcid"`
+	UserId        sql.NullInt64  `json:"user_id"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+	CreatedAt     time.Time      `json:"created_at"`
+	MiddleInitial sql.NullString `json:"middle_initial"`
+	Degree        sql.NullString `json:"degree"`
+}

--- a/pkg/models/pgdb/dataUseAgreementsTable.go
+++ b/pkg/models/pgdb/dataUseAgreementsTable.go
@@ -1,0 +1,12 @@
+package pgdb
+
+import "time"
+
+type DataUseAgreement struct {
+	Id          int64     `json:"id"`
+	Name        string    `json:"name"`
+	Body        string    `json:"body"`
+	CreatedAt   time.Time `json:"created_at"`
+	IsDefault   bool      `json:"is_default"`
+	Description string    `json:"description"`
+}

--- a/pkg/models/pgdb/datasetTable.go
+++ b/pkg/models/pgdb/datasetTable.go
@@ -80,3 +80,11 @@ type DatasetTeam struct {
 	CreatedAt time.Time    `json:"created_at"`
 	UpdatedAt time.Time    `json:"updated_at"`
 }
+
+type DatasetContributor struct {
+	DatasetId        int64     `json:"dataset_id"`
+	ContributorId    int64     `json:"contributor_id"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	ContributorOrder int64     `json:"contributor_order"`
+}

--- a/pkg/models/pgdb/datasetTable.go
+++ b/pkg/models/pgdb/datasetTable.go
@@ -55,6 +55,16 @@ type Dataset struct {
 	ChangelogId                  uuid.NullUUID  `json:"changelog_id"`
 }
 
+type DatasetStatus struct {
+	Id           int64     `json:"id"`
+	Name         string    `json:"name"`
+	DisplayName  string    `json:"display_name"`
+	OriginalName string    `json:"original_name"`
+	Color        string    `json:"color"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
 type DatasetUser struct {
 	DatasetId int64        `json:"dataset_id"`
 	UserId    int64        `json:"user_id"`

--- a/pkg/models/pgdb/organizationUserTable.go
+++ b/pkg/models/pgdb/organizationUserTable.go
@@ -8,7 +8,7 @@ type DbPermission int64
 
 const (
 	NoPermission DbPermission = 0
-	Collaborate               = 1
+	Guest                     = 1
 	Read                      = 2
 	Write                     = 4
 	Delete                    = 8
@@ -20,8 +20,8 @@ func (s DbPermission) String() string {
 	switch s {
 	case NoPermission:
 		return "NoPermission"
-	case Collaborate:
-		return "Collaborate"
+	case Guest:
+		return "Guest"
 	case Read:
 		return "Read"
 	case Write:
@@ -39,8 +39,8 @@ func (s DbPermission) String() string {
 
 type OrganizationUser struct {
 	OrganizationId int64        `json:"organization_id"`
-	UserId       int64        `json:"user_id"`
-	DbPermission DbPermission `json:"permission_bit"`
-	CreatedAt    time.Time    `json:"created_at"`
+	UserId         int64        `json:"user_id"`
+	DbPermission   DbPermission `json:"permission_bit"`
+	CreatedAt      time.Time    `json:"created_at"`
 	UpdatedAt      time.Time    `json:"updated_at"`
 }

--- a/pkg/queries/dydb/manifests_test.go
+++ b/pkg/queries/dydb/manifests_test.go
@@ -67,7 +67,7 @@ func testUpdateManifestStatus(t *testing.T, client *DynamoStore) {
 	ctx := context.Background()
 	manifestId := "1111"
 
-	err := client.updateManifestStatus(ctx, manifestTableName, manifestId, manifest.Completed)
+	err := client.UpdateManifestStatus(ctx, manifestTableName, manifestId, manifest.Completed)
 	assert.Nil(t, err, "Manifest status could not be updated")
 
 	out, err := client.GetManifestById(ctx, manifestTableName, manifestId)

--- a/pkg/queries/pgdb/contributors.go
+++ b/pkg/queries/pgdb/contributors.go
@@ -1,0 +1,139 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+type ContributorNotFoundError struct {
+	err error
+}
+
+func (e ContributorNotFoundError) Error() string {
+	return fmt.Sprintf("contributor was not found (error: %v)", e.err)
+}
+
+type NewContributor struct {
+	FirstName     string
+	MiddleInitial string
+	LastName      string
+	Degree        string
+	EmailAddress  string
+	Orcid         string
+	UserId        int64
+}
+
+func ContributorColumns() []string {
+	columns := []string{
+		"id",
+		"first_name",
+		"last_name",
+		"email",
+		"orcid",
+		"user_id",
+		"updated_at",
+		"created_at",
+		"middle_initial",
+		"degree"}
+	return columns
+}
+
+func ReadContributorColumns() string {
+	return strings.Join(ContributorColumns(), ",")
+}
+
+func WriteContributorColumns() string {
+	// TODO: filter out "id", "updated_at", "created_at"
+	return strings.Join(ContributorColumns(), ",")
+}
+
+func scanContributor(row *sql.Row) (*pgdb.Contributor, error) {
+	var contributor pgdb.Contributor
+
+	err := row.Scan(
+		&contributor.Id,
+		&contributor.FirstName,
+		&contributor.LastName,
+		&contributor.Email,
+		&contributor.Orcid,
+		&contributor.UserId,
+		&contributor.UpdatedAt,
+		&contributor.CreatedAt,
+		&contributor.MiddleInitial,
+		&contributor.Degree)
+
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return nil, ContributorNotFoundError{err}
+		default:
+			log.Error("Unknown Error while scanning dataset row: ", err)
+			panic(err)
+		}
+	}
+	return &contributor, nil
+}
+
+func getContributor(ctx context.Context, db DBTX, query string) (*pgdb.Contributor, error) {
+	return scanContributor(db.QueryRowContext(ctx, query))
+}
+
+// AddContributor will add a Contributor to the Organization's Contributors table.
+func (q *Queries) AddContributor(ctx context.Context, contributor NewContributor) (*pgdb.Contributor, error) {
+	var err error
+	if contributor.UserId > 0 {
+		_, err = q.db.ExecContext(ctx,
+			"INSERT INTO contributors (first_name, middle_initial, last_name, degree, email, orcid, user_id) VALUES($1, $2, $3, $4, $5, $6, $7)",
+			contributor.FirstName,
+			contributor.MiddleInitial,
+			contributor.LastName,
+			contributor.Degree,
+			contributor.EmailAddress,
+			contributor.Orcid,
+			contributor.UserId)
+	} else {
+		_, err = q.db.ExecContext(ctx,
+			"INSERT INTO contributors (first_name, middle_initial, last_name, degree, email, orcid) VALUES($1, $2, $3, $4, $5, $6)",
+			contributor.FirstName,
+			contributor.MiddleInitial,
+			contributor.LastName,
+			contributor.Degree,
+			contributor.EmailAddress,
+			contributor.Orcid)
+	}
+
+	// ExecContext returned an error
+	if err != nil {
+		return nil, err
+	}
+
+	return q.GetContributorByEmail(ctx, contributor.EmailAddress)
+}
+
+// GetContributor will get a Contributor by the Contributor Id (not the User Id).
+func (q *Queries) GetContributor(ctx context.Context, id int64) (*pgdb.Contributor, error) {
+	query := fmt.Sprintf("SELECT %s FROM contributors WHERE id=%d", ReadContributorColumns(), id)
+	return getContributor(ctx, q.db, query)
+}
+
+// GetContributorByUserId will get a Contributor by User Id.
+func (q *Queries) GetContributorByUserId(ctx context.Context, userId int64) (*pgdb.Contributor, error) {
+	query := fmt.Sprintf("SELECT %s FROM contributors WHERE user_id=%d", ReadContributorColumns(), userId)
+	return getContributor(ctx, q.db, query)
+}
+
+// GetContributorByEmail will get a Contributor by Email Address.
+func (q *Queries) GetContributorByEmail(ctx context.Context, email string) (*pgdb.Contributor, error) {
+	query := fmt.Sprintf("SELECT %s FROM contributors WHERE email='%s'", ReadContributorColumns(), email)
+	return getContributor(ctx, q.db, query)
+}
+
+// GetContributorByOrcid will get a Contributor by ORCID iD.
+func (q *Queries) GetContributorByOrcid(ctx context.Context, orcid string) (*pgdb.Contributor, error) {
+	query := fmt.Sprintf("SELECT %s FROM contributors WHERE orcid='%s'", ReadContributorColumns(), orcid)
+	return getContributor(ctx, q.db, query)
+}

--- a/pkg/queries/pgdb/contributors_test.go
+++ b/pkg/queries/pgdb/contributors_test.go
@@ -1,0 +1,99 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestContributors(t *testing.T) {
+	orgId := 3
+	db := testDB[orgId]
+	store := NewSQLStore(db)
+
+	//addTestDataset(db, "Test Dataset - with Contributors")
+	//defer test.Truncate(t, db, orgId, "datasets")
+
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Add Contributor Existing User": testAddContributorExistingUser,
+		"Add Contributor External":      testAddContributorExternal,
+		"Get Contributor By Id":         testGetContributorById,
+		"Get Contributor By User Id":    testGetContributorByUserId,
+		"Get Contributor By Email":      testGetContributorByEmail,
+		"Get Contributor By Orcid":      testGetContributorByOrcid,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := orgId
+			store := store
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testAddContributorExistingUser(t *testing.T, store *SQLStore, orgId int) {
+	// get an existing user
+	user, err := store.GetUserById(context.TODO(), 1003)
+	assert.NoError(t, err)
+
+	newContributor := NewContributor{
+		FirstName:    user.FirstName,
+		LastName:     user.LastName,
+		EmailAddress: user.Email,
+		UserId:       user.Id,
+	}
+
+	contributor, err := store.AddContributor(context.TODO(), newContributor)
+	assert.NoError(t, err)
+	assert.Equal(t, user.FirstName, contributor.FirstName)
+	assert.Equal(t, user.LastName, contributor.LastName)
+	assert.Equal(t, user.Email, contributor.Email)
+	assert.Equal(t, sql.NullInt64{Int64: user.Id, Valid: true}, contributor.UserId)
+}
+
+func testAddContributorExternal(t *testing.T, store *SQLStore, orgId int) {
+	newContributor := NewContributor{
+		FirstName:     "Someone",
+		MiddleInitial: "X",
+		LastName:      "Ternal",
+		Degree:        "MD",
+		EmailAddress:  "someone.x.ternal@not-pennsieve.org",
+		Orcid:         "0000-0000-0000-4321",
+	}
+
+	contributor, err := store.AddContributor(context.TODO(), newContributor)
+	assert.NoError(t, err)
+	assert.Equal(t, newContributor.EmailAddress, contributor.Email)
+	assert.Equal(t, sql.NullString{String: newContributor.Orcid, Valid: true}, contributor.Orcid)
+}
+
+func testGetContributorById(t *testing.T, store *SQLStore, orgId int) {
+	contributorId := int64(1)
+	contributor, err := store.GetContributor(context.TODO(), contributorId)
+	assert.NoError(t, err)
+	assert.Equal(t, contributorId, contributor.Id)
+	assert.Equal(t, "user4@pennsieve.org", contributor.Email)
+}
+
+func testGetContributorByUserId(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(1004)
+	contributor, err := store.GetContributorByUserId(context.TODO(), userId)
+	assert.NoError(t, err)
+	assert.Equal(t, sql.NullInt64{Int64: userId, Valid: true}, contributor.UserId)
+}
+
+func testGetContributorByEmail(t *testing.T, store *SQLStore, orgId int) {
+	email := "user@external.org"
+	contributor, err := store.GetContributorByEmail(context.TODO(), email)
+	assert.NoError(t, err)
+	assert.Equal(t, email, contributor.Email)
+}
+
+func testGetContributorByOrcid(t *testing.T, store *SQLStore, orgId int) {
+	orcid := "0000-0000-0000-1234"
+	contributor, err := store.GetContributorByOrcid(context.TODO(), orcid)
+	assert.NoError(t, err)
+	assert.Equal(t, sql.NullString{String: orcid, Valid: true}, contributor.Orcid)
+}

--- a/pkg/queries/pgdb/dataUseAgreements.go
+++ b/pkg/queries/pgdb/dataUseAgreements.go
@@ -1,0 +1,37 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetDefaultDataUseAgreement will return the default data use agreement for the organization.
+func (q *Queries) GetDefaultDataUseAgreement(ctx context.Context, organizationId int) (*pgdb.DataUseAgreement, error) {
+	query := fmt.Sprintf("SELECT * FROM \"%d\".data_use_agreements where is_default = true;", organizationId)
+
+	row := q.db.QueryRowContext(ctx, query)
+	dataUseAgreement := pgdb.DataUseAgreement{}
+	err := row.Scan(
+		&dataUseAgreement.Id,
+		&dataUseAgreement.Name,
+		&dataUseAgreement.Body,
+		&dataUseAgreement.CreatedAt,
+		&dataUseAgreement.IsDefault,
+		&dataUseAgreement.Description)
+
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			log.Error("No rows were returned!")
+			return nil, err
+		default:
+			log.Error("Unknown Error while scanning data_use_agreements table: ", err)
+			panic(err)
+		}
+	}
+
+	return &dataUseAgreement, nil
+}

--- a/pkg/queries/pgdb/dataUseAgreements.go
+++ b/pkg/queries/pgdb/dataUseAgreements.go
@@ -10,7 +10,8 @@ import (
 
 // GetDefaultDataUseAgreement will return the default data use agreement for the organization.
 func (q *Queries) GetDefaultDataUseAgreement(ctx context.Context, organizationId int) (*pgdb.DataUseAgreement, error) {
-	query := fmt.Sprintf("SELECT * FROM \"%d\".data_use_agreements where is_default = true;", organizationId)
+	query := fmt.Sprintf("SELECT id, name, body, created_at, is_default, description"+
+		" FROM \"%d\".data_use_agreements where is_default = true;", organizationId)
 
 	row := q.db.QueryRowContext(ctx, query)
 	dataUseAgreement := pgdb.DataUseAgreement{}

--- a/pkg/queries/pgdb/dataUseAgreements_test.go
+++ b/pkg/queries/pgdb/dataUseAgreements_test.go
@@ -1,0 +1,28 @@
+package pgdb
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDataUseAgreements(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Get Default Data Use Agreement": testGetDefaultDataUseAgreement,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := 2
+			store := NewSQLStore(testDB[orgId])
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testGetDefaultDataUseAgreement(t *testing.T, store *SQLStore, orgId int) {
+	expectedId := int64(1001)
+	dataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedId, dataUseAgreement.Id)
+}

--- a/pkg/queries/pgdb/dataUseAgreements_test.go
+++ b/pkg/queries/pgdb/dataUseAgreements_test.go
@@ -7,14 +7,18 @@ import (
 )
 
 func TestDataUseAgreements(t *testing.T) {
+	orgId := 2
+	db := testDB[orgId]
+	store := NewSQLStore(db)
+
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
 		"Get Default Data Use Agreement": testGetDefaultDataUseAgreement,
 	} {
 		t.Run(scenario, func(t *testing.T) {
-			orgId := 2
-			store := NewSQLStore(testDB[orgId])
+			orgId := orgId
+			store := store
 			fn(t, store, orgId)
 		})
 	}

--- a/pkg/queries/pgdb/datasetContributor.go
+++ b/pkg/queries/pgdb/datasetContributor.go
@@ -1,0 +1,1 @@
+package pgdb

--- a/pkg/queries/pgdb/datasetContributor.go
+++ b/pkg/queries/pgdb/datasetContributor.go
@@ -1,1 +1,32 @@
 package pgdb
+
+import (
+	"context"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+)
+
+func (q *Queries) GetDatasetContributor(ctx context.Context, datasetId int64, contributorId int64) (*pgdb.DatasetContributor, error) {
+	query := "SELECT dataset_id, contributor_id, created_at, updated_at, contributor_order FROM dataset_contributor WHERE dataset_id=$1 and contributor_id=$2"
+	var datasetContributor pgdb.DatasetContributor
+	err := q.db.QueryRowContext(ctx, query, datasetId, contributorId).Scan(
+		&datasetContributor.DatasetId,
+		&datasetContributor.ContributorId,
+		&datasetContributor.CreatedAt,
+		&datasetContributor.UpdatedAt,
+		&datasetContributor.ContributorOrder)
+
+	if err != nil {
+		return nil, err
+	}
+	return &datasetContributor, nil
+}
+
+func (q *Queries) AddDatasetContributor(ctx context.Context, dataset *pgdb.Dataset, contributor *pgdb.Contributor) (*pgdb.DatasetContributor, error) {
+	position := int64(1)
+	statement := "INSERT INTO dataset_contributor(dataset_id, contributor_id, contributor_order) VALUES($1, $2, $3)"
+	_, err := q.db.ExecContext(ctx, statement, dataset.Id, contributor.Id, position)
+	if err != nil {
+		return nil, err
+	}
+	return q.GetDatasetContributor(ctx, dataset.Id, contributor.Id)
+}

--- a/pkg/queries/pgdb/datasetContributor_test.go
+++ b/pkg/queries/pgdb/datasetContributor_test.go
@@ -1,0 +1,53 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"github.com/pennsieve/pennsieve-go-core/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDatasetContributor(t *testing.T) {
+	orgId := 3
+	db := testDB[orgId]
+	store := NewSQLStore(db)
+
+	addTestDataset(db, "Test Dataset - AddDatasetContributor")
+	defer test.Truncate(t, db, orgId, "datasets")
+
+	//addTestDataset(db, "Test Dataset - with Contributors")
+	//defer test.Truncate(t, db, orgId, "datasets")
+
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Add Dataset Contributor": testAddDatasetContributor,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := orgId
+			store := store
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testAddDatasetContributor(t *testing.T, store *SQLStore, orgId int) {
+	// get the dataset
+	datasetName := "Test Dataset - AddDatasetContributor"
+	ds, err := store.GetDatasetByName(context.TODO(), datasetName)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetName, ds.Name)
+
+	// get the contributor
+	userId := int64(1004)
+	contributor, err := store.GetContributorByUserId(context.TODO(), userId)
+	assert.NoError(t, err)
+	assert.Equal(t, sql.NullInt64{Int64: userId, Valid: true}, contributor.UserId)
+
+	// add the dataset contributor
+	datasetContributor, err := store.AddDatasetContributor(context.TODO(), ds, contributor)
+	assert.NoError(t, err)
+	assert.Equal(t, ds.Id, datasetContributor.DatasetId)
+	assert.Equal(t, contributor.Id, datasetContributor.ContributorId)
+}

--- a/pkg/queries/pgdb/datasetStatus.go
+++ b/pkg/queries/pgdb/datasetStatus.go
@@ -1,0 +1,39 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetDefaultDatasetStatus will return the default dataset status for the organization.
+// This is assumed to be the dataset status row with the lowest id number.
+func (q *Queries) GetDefaultDatasetStatus(ctx context.Context, organizationId int) (*pgdb.DatasetStatus, error) {
+	query := fmt.Sprintf("SELECT * FROM \"%d\".dataset_status order by id limit 1;", organizationId)
+
+	row := q.db.QueryRowContext(ctx, query)
+	datasetStatus := pgdb.DatasetStatus{}
+	err := row.Scan(
+		&datasetStatus.Id,
+		&datasetStatus.Name,
+		&datasetStatus.DisplayName,
+		&datasetStatus.OriginalName,
+		&datasetStatus.Color,
+		&datasetStatus.CreatedAt,
+		&datasetStatus.UpdatedAt)
+
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			log.Error("No rows were returned!")
+			return nil, err
+		default:
+			log.Error("Unknown Error while scanning dataset_status table: ", err)
+			panic(err)
+		}
+	}
+
+	return &datasetStatus, nil
+}

--- a/pkg/queries/pgdb/datasetStatus.go
+++ b/pkg/queries/pgdb/datasetStatus.go
@@ -11,7 +11,8 @@ import (
 // GetDefaultDatasetStatus will return the default dataset status for the organization.
 // This is assumed to be the dataset status row with the lowest id number.
 func (q *Queries) GetDefaultDatasetStatus(ctx context.Context, organizationId int) (*pgdb.DatasetStatus, error) {
-	query := fmt.Sprintf("SELECT * FROM \"%d\".dataset_status order by id limit 1;", organizationId)
+	query := fmt.Sprintf("SELECT id, name, display_name, original_name, color, created_at, updated_at"+
+		" FROM \"%d\".dataset_status order by id limit 1;", organizationId)
 
 	row := q.db.QueryRowContext(ctx, query)
 	datasetStatus := pgdb.DatasetStatus{}

--- a/pkg/queries/pgdb/datasetStatus_test.go
+++ b/pkg/queries/pgdb/datasetStatus_test.go
@@ -1,0 +1,28 @@
+package pgdb
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDatasetStatus(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Get Default Dataset Status": testGetDefaultDatasetStatus,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := 1
+			store := NewSQLStore(testDB[orgId])
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testGetDefaultDatasetStatus(t *testing.T, store *SQLStore, orgId int) {
+	expectedId := int64(1)
+	datasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedId, datasetStatus.Id)
+}

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -1,6 +1,7 @@
 package pgdb
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
@@ -59,4 +60,25 @@ func TestDatasetsInsertSelect(t *testing.T) {
 		}
 	}
 
+}
+
+func TestDatasets(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Get Dataset by Name": testGetDatasetByName,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := 1
+			store := NewSQLStore(testDB[orgId])
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testGetDatasetByName(t *testing.T, store *SQLStore, orgId int) {
+	name := "Test Dataset 2"
+	dataset, err := store.GetDatasetByName(context.TODO(), orgId, name)
+	assert.NoError(t, err)
+	assert.Equal(t, name, dataset.Name)
 }

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -68,7 +68,8 @@ func TestDatasets(t *testing.T) {
 	db := testDB[orgId]
 	store := NewSQLStore(db)
 
-	addTestDataset(db, "Test Dataset - GetByName")
+	addTestDataset(db, "Test Dataset - GetDatasetByName")
+	addTestDataset(db, "Test Dataset - AddUserToDataset")
 	defer test.Truncate(t, db, orgId, "datasets")
 
 	for scenario, fn := range map[string]func(
@@ -87,7 +88,7 @@ func TestDatasets(t *testing.T) {
 }
 
 func testGetDatasetByName(t *testing.T, store *SQLStore, orgId int) {
-	name := "Test Dataset - GetByName"
+	name := "Test Dataset - GetDatasetByName"
 	ds, err := store.GetDatasetByName(context.TODO(), name)
 	assert.NoError(t, err)
 	assert.Equal(t, name, ds.Name)
@@ -104,8 +105,8 @@ func testCreateDataset(t *testing.T, store *SQLStore, orgId int) {
 		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
 	}
 	createDatasetParams := CreateDatasetParams{
-		Name:                         "test create Go Core API",
-		Description:                  "dataset creation test",
+		Name:                         "Test Dataset - CreateDataset",
+		Description:                  "Test Dataset - CreateDataset",
 		Status:                       defaultDatasetStatus,
 		AutomaticallyProcessPackages: false,
 		License:                      "",
@@ -118,7 +119,7 @@ func testCreateDataset(t *testing.T, store *SQLStore, orgId int) {
 }
 
 func testAddUserToDataset(t *testing.T, store *SQLStore, orgId int) {
-	ds, err := store.GetDatasetByName(context.TODO(), "test create Go Core API")
+	ds, err := store.GetDatasetByName(context.TODO(), "Test Dataset - AddUserToDataset")
 	assert.NoError(t, err)
 
 	user, err := store.GetUserById(context.TODO(), 1003)

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -67,6 +67,7 @@ func TestDatasets(t *testing.T) {
 		tt *testing.T, store *SQLStore, orgId int,
 	){
 		"Get Dataset by Name": testGetDatasetByName,
+		"Create Dataset":      testCreateDataset,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 1
@@ -78,7 +79,25 @@ func TestDatasets(t *testing.T) {
 
 func testGetDatasetByName(t *testing.T, store *SQLStore, orgId int) {
 	name := "Test Dataset 2"
-	dataset, err := store.GetDatasetByName(context.TODO(), orgId, name)
+	dataset, err := store.GetDatasetByName(context.TODO(), name)
 	assert.NoError(t, err)
 	assert.Equal(t, name, dataset.Name)
+}
+
+func testCreateDataset(t *testing.T, store *SQLStore, orgId int) {
+	var err error
+	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
+	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
+	create := CreateDatasetParams{
+		Name:                         "test create Go Core API",
+		Description:                  "dataset creation test",
+		Status:                       defaultDatasetStatus,
+		AutomaticallyProcessPackages: false,
+		License:                      "",
+		Tags:                         nil,
+		DataUseAgreement:             defaultDataUseAgreement,
+	}
+	dataset, err := store.CreateDataset(context.TODO(), create)
+	assert.NoError(t, err)
+	assert.Equal(t, create.Name, dataset.Name)
 }

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -34,6 +34,30 @@ func (q *Queries) GetOrganizationUserById(ctx context.Context, id int64) (*pgdb.
 	}
 }
 
+func (q *Queries) GetOrganizationUser(ctx context.Context, orgId int64, userId int64) (*pgdb.OrganizationUser, error) {
+	queryStr := "SELECT organization_id, user_id, permission_bit, created_at, updated_at " +
+		"FROM pennsieve.organization_user WHERE organization_id=$1 AND user_id=$2;"
+
+	var orgUser pgdb.OrganizationUser
+	row := q.db.QueryRowContext(ctx, queryStr, orgId, userId)
+	err := row.Scan(
+		&orgUser.OrganizationId,
+		&orgUser.UserId,
+		&orgUser.DbPermission,
+		&orgUser.CreatedAt,
+		&orgUser.UpdatedAt)
+
+	switch err {
+	case sql.ErrNoRows:
+		fmt.Println("No rows were returned!")
+		return nil, err
+	case nil:
+		return &orgUser, nil
+	default:
+		panic(err)
+	}
+}
+
 // GetOrganizationClaim returns an organization claim for a specific user.
 func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organizationId int64) (*organization.Claim, error) {
 

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -58,6 +58,22 @@ func (q *Queries) GetOrganizationUser(ctx context.Context, orgId int64, userId i
 	}
 }
 
+func (q *Queries) AddOrganizationUser(ctx context.Context, orgId int64, userId int64, permBit pgdb.DbPermission) (*pgdb.OrganizationUser, error) {
+	statement := "INSERT INTO pennsieve.organization_user (organization_id, user_id, permission_bit) VALUES ($1, $2, $3)"
+
+	_, err := q.db.ExecContext(ctx, statement, orgId, userId, permBit)
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("database error on insert: %v", err))
+	}
+
+	orgUser, err := q.GetOrganizationUser(ctx, orgId, userId)
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("database error on query: %v", err))
+	}
+
+	return orgUser, nil
+}
+
 // GetOrganizationClaim returns an organization claim for a specific user.
 func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organizationId int64) (*organization.Claim, error) {
 

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -3,6 +3,7 @@ package pgdb
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
 	log "github.com/sirupsen/logrus"

--- a/pkg/queries/pgdb/organizationUser_test.go
+++ b/pkg/queries/pgdb/organizationUser_test.go
@@ -2,6 +2,7 @@ package pgdb
 
 import (
 	"context"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -10,7 +11,9 @@ func TestOrganizationUser(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
-		"Get Organization User": testGetOrganizationUser,
+		"Get Organization User":     testGetOrganizationUser,
+		"Add Organization User":     testAddOrganizationUser,
+		"Add Guest to Organization": testAddGuestToOrganization,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 1
@@ -28,4 +31,28 @@ func testGetOrganizationUser(t *testing.T, store *SQLStore, orgId int) {
 	assert.NoError(t, err)
 	assert.Equal(t, userId, orgUser.UserId)
 	assert.Equal(t, organizationId, orgUser.OrganizationId)
+}
+
+func testAddOrganizationUser(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(1001)
+	organizationId := int64(2)
+	permissionBit := pgdb.DbPermission(pgdb.Delete)
+
+	orgUser, err := store.AddOrganizationUser(context.TODO(), organizationId, userId, permissionBit)
+	assert.NoError(t, err)
+	assert.Equal(t, userId, orgUser.UserId)
+	assert.Equal(t, organizationId, orgUser.OrganizationId)
+	assert.Equal(t, permissionBit, orgUser.DbPermission)
+}
+
+func testAddGuestToOrganization(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(1001)
+	organizationId := int64(3)
+	permissionBit := pgdb.DbPermission(pgdb.Guest)
+
+	orgUser, err := store.AddOrganizationUser(context.TODO(), organizationId, userId, permissionBit)
+	assert.NoError(t, err)
+	assert.Equal(t, userId, orgUser.UserId)
+	assert.Equal(t, organizationId, orgUser.OrganizationId)
+	assert.Equal(t, permissionBit, orgUser.DbPermission)
 }

--- a/pkg/queries/pgdb/organizationUser_test.go
+++ b/pkg/queries/pgdb/organizationUser_test.go
@@ -11,9 +11,10 @@ func TestOrganizationUser(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
-		"Get Organization User":     testGetOrganizationUser,
-		"Add Organization User":     testAddOrganizationUser,
-		"Add Guest to Organization": testAddGuestToOrganization,
+		"Get Organization User":           testGetOrganizationUser,
+		"Add Organization User":           testAddOrganizationUser,
+		"Add Existing OrgUser Membership": testAddExistingOrgUserMembership,
+		"Add Guest to Organization":       testAddGuestToOrganization,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 1
@@ -43,6 +44,19 @@ func testAddOrganizationUser(t *testing.T, store *SQLStore, orgId int) {
 	assert.Equal(t, userId, orgUser.UserId)
 	assert.Equal(t, organizationId, orgUser.OrganizationId)
 	assert.Equal(t, permissionBit, orgUser.DbPermission)
+}
+
+// testAddExistingOrgUserMembership should not update the user's organization membership
+func testAddExistingOrgUserMembership(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(1001)
+	organizationId := int64(1)
+	permissionBit := pgdb.DbPermission(pgdb.Administer)
+
+	orgUser, err := store.AddOrganizationUser(context.TODO(), organizationId, userId, permissionBit)
+	assert.NoError(t, err)
+	assert.Equal(t, userId, orgUser.UserId)
+	assert.Equal(t, organizationId, orgUser.OrganizationId)
+	assert.NotEqual(t, permissionBit, orgUser.DbPermission)
 }
 
 func testAddGuestToOrganization(t *testing.T, store *SQLStore, orgId int) {

--- a/pkg/queries/pgdb/organizationUser_test.go
+++ b/pkg/queries/pgdb/organizationUser_test.go
@@ -1,0 +1,31 @@
+package pgdb
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOrganizationUser(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Get Organization User": testGetOrganizationUser,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := 1
+			store := NewSQLStore(testDB[orgId])
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testGetOrganizationUser(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(1001)
+	organizationId := int64(1)
+
+	orgUser, err := store.GetOrganizationUser(context.TODO(), organizationId, userId)
+	assert.NoError(t, err)
+	assert.Equal(t, userId, orgUser.UserId)
+	assert.Equal(t, organizationId, orgUser.OrganizationId)
+}

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -3,6 +3,7 @@ package pgdb
 import (
 	"database/sql"
 	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/nodeId"
 	log "github.com/sirupsen/logrus"
 	"os"
 	"testing"
@@ -36,6 +37,7 @@ func TestMain(m *testing.M) {
 		log.Fatal("cannot connect to db:", err)
 	}
 	testDB[2] = db2
+
 	addDatasetStatus(db2)
 	addDataUseAgreements(db2)
 
@@ -44,6 +46,8 @@ func TestMain(m *testing.M) {
 		log.Fatal("cannot connect to db:", err)
 	}
 	testDB[3] = db3
+	addDatasetStatus(db3)
+	addDataUseAgreements(db3)
 
 	os.Exit(m.Run())
 }
@@ -94,6 +98,18 @@ func addDataset(db *sql.DB) {
 		log.Fatal(fmt.Sprintf("Unable to add dataset for test: %v", err))
 	}
 
+}
+
+func addTestDataset(db *sql.DB, datasetName string) {
+	datasetNodeId := nodeId.NodeId(nodeId.DataSetCode)
+	datasetState := "READY"
+	datasetStatusId := 1
+	statement := fmt.Sprintf("INSERT INTO datasets (name, node_id, state, status_id) VALUES ('%s', '%s', '%s', %d);",
+		datasetName, datasetNodeId, datasetState, datasetStatusId)
+	_, err := db.Exec(statement)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Unable to add dataset for test: %v", err))
+	}
 }
 
 // TestStore is the main Test Suite function for Packages.

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -31,11 +31,19 @@ func TestMain(m *testing.M) {
 	// Add stub dataset for testing against other datasets within same org.
 	addDataset(db1)
 
-	db2, err := ConnectENVWithOrg(3)
+	db2, err := ConnectENVWithOrg(2)
 	if err != nil {
 		log.Fatal("cannot connect to db:", err)
 	}
-	testDB[3] = db2
+	testDB[2] = db2
+	addDatasetStatus(db2)
+	addDataUseAgreements(db2)
+
+	db3, err := ConnectENVWithOrg(3)
+	if err != nil {
+		log.Fatal("cannot connect to db:", err)
+	}
+	testDB[3] = db3
 
 	os.Exit(m.Run())
 }
@@ -53,6 +61,30 @@ func addUsers(db *sql.DB) {
 		" VALUES (1002, 'N:user:2', 'user2@pennsieve.org', 'second', 'user', 1, '22222222-2222-2222-2222-222222222222', 'f')")
 	if err != nil {
 		log.Fatal(fmt.Sprintf("Unable to add user (2) for test: %v", err))
+	}
+}
+
+func addDatasetStatus(db *sql.DB) {
+	var err error
+	_, err = db.Exec("INSERT INTO dataset_status (id, name, display_name, original_name, color) VALUES (1001, 'Initial_Status', 'Initial Status', 'Initial_Status', '#000000')")
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Unable to add dataset_status (1) for test: %v", err))
+	}
+	_, err = db.Exec("INSERT INTO dataset_status (id, name, display_name, original_name, color) VALUES (1002, 'Second_Status', 'Second Status', 'Second_Status', '#000000')")
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Unable to add dataset_status (2) for test: %v", err))
+	}
+}
+
+func addDataUseAgreements(db *sql.DB) {
+	var err error
+	_, err = db.Exec("INSERT INTO data_use_agreements (id, name, body, description, is_default) VALUES (1001, 'Data Use Agreement General', 'Use the data any way you like.', 'for general, unrestricted use', true)")
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Unable to add data_use_agreements (1) for test: %v", err))
+	}
+	_, err = db.Exec("INSERT INTO data_use_agreements (id, name, body, description, is_default) VALUES (1002, 'Data Use Agreement Restricted', 'Use the data as permitted.', 'requires authorization', false)")
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Unable to add data_use_agreements (2) for test: %v", err))
 	}
 }
 

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -39,7 +39,6 @@ func TestMain(m *testing.M) {
 		log.Fatal("cannot connect to db:", err)
 	}
 	testDB[2] = db2
-
 	addDatasetStatus(db2)
 	addDataUseAgreements(db2)
 

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -55,18 +55,31 @@ func TestMain(m *testing.M) {
 }
 
 func addUsers(db *sql.DB) {
-	var err error
-
-	_, err = db.Exec("INSERT INTO pennsieve.users (id, node_id, email, first_name, last_name, preferred_org_id, cognito_id, is_super_admin)" +
-		" VALUES (1001, 'N:user:1', 'user1@pennsieve.org', 'first', 'user', 1, '11111111-1111-1111-1111-111111111111', 'f')")
-	if err != nil {
-		log.Fatal(fmt.Sprintf("Unable to add user (1) for test: %v", err))
+	type Users struct {
+		userId         int64
+		nodeId         string
+		emailAddress   string
+		firstName      string
+		lastName       string
+		preferredOrgId int64
+		cognitoId      string
+		isSuperAdmin   string
 	}
 
-	_, err = db.Exec("INSERT INTO pennsieve.users (id, node_id, email, first_name, last_name, preferred_org_id, cognito_id, is_super_admin)" +
-		" VALUES (1002, 'N:user:2', 'user2@pennsieve.org', 'second', 'user', 1, '22222222-2222-2222-2222-222222222222', 'f')")
-	if err != nil {
-		log.Fatal(fmt.Sprintf("Unable to add user (2) for test: %v", err))
+	users := []Users{
+		{userId: 1001, nodeId: "N:user:1", emailAddress: "user1@pennsieve.org", firstName: "one", lastName: "user", preferredOrgId: 1, cognitoId: "11111111-1111-1111-1111-111111111111", isSuperAdmin: "f"},
+		{userId: 1002, nodeId: "N:user:2", emailAddress: "user2@pennsieve.org", firstName: "two", lastName: "user", preferredOrgId: 2, cognitoId: "22222222-2222-2222-2222-222222222222", isSuperAdmin: "f"},
+		{userId: 1003, nodeId: "N:user:3", emailAddress: "user3@pennsieve.org", firstName: "three", lastName: "user", preferredOrgId: 3, cognitoId: "33333333-3333-3333-3333-333333333333", isSuperAdmin: "f"},
+	}
+
+	statement := "INSERT INTO pennsieve.users (id, node_id, email, first_name, last_name, preferred_org_id, cognito_id, is_super_admin)" +
+		"VALUES($1, $2, $3, $4, $5, $6, $7, $8);"
+
+	for _, user := range users {
+		_, err := db.Exec(statement, user.userId, user.nodeId, user.emailAddress, user.firstName, user.lastName, user.preferredOrgId, user.cognitoId, user.isSuperAdmin)
+		if err != nil {
+			log.Fatal(fmt.Sprintf("unable to add user with userId: %d", user.userId))
+		}
 	}
 }
 
@@ -79,7 +92,8 @@ func addUsersToOrganizations(db *sql.DB) {
 
 	memberships := []OrgUserPermission{
 		{organizationId: 1, userId: 1001, permissionBit: pgdb.Delete},
-		{organizationId: 1, userId: 1002, permissionBit: pgdb.Delete},
+		{organizationId: 2, userId: 1002, permissionBit: pgdb.Delete},
+		{organizationId: 3, userId: 1003, permissionBit: pgdb.Delete},
 	}
 
 	statement := "INSERT INTO pennsieve.organization_user (organization_id, user_id, permission_bit) VALUES ($1, $2, $3)"

--- a/pkg/queries/pgdb/users.go
+++ b/pkg/queries/pgdb/users.go
@@ -36,9 +36,9 @@ func (q *Queries) GetByCognitoId(ctx context.Context, id string) (*pgdb.User, er
 	}
 }
 
-// GetById returns a user from Postgres based on the user's int id
+// GetUserById returns a user from Postgres based on the user's int id
 // This function also returns the preferred org and whether the user is a super-admin.
-func (q *Queries) GetById(ctx context.Context, id int64) (*pgdb.User, error) {
+func (q *Queries) GetUserById(ctx context.Context, id int64) (*pgdb.User, error) {
 
 	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, preferred_org_id " +
 		"FROM pennsieve.users WHERE id=$1;"

--- a/pkg/queries/pgdb/users_test.go
+++ b/pkg/queries/pgdb/users_test.go
@@ -24,7 +24,7 @@ func TestUsers(t *testing.T) {
 
 func testGetUserByID(t *testing.T, store *SQLStore, orgId int) {
 	id := int64(1001)
-	user, err := store.GetById(context.TODO(), id)
+	user, err := store.GetUserById(context.TODO(), id)
 	assert.NoError(t, err)
 	assert.Equal(t, user.Id, id)
 }


### PR DESCRIPTION
This PR adds some initial capability to create a Dataset. 

All of the small pieces of functionality added here are largely based on what the Pennsieve API "Create Dataset" endpoint performs. Each of these attempt to stand on their own; there is not yet a single entry point which fully mimics the Pennsieve API "Create Dataset" endpoint -- this function will likely need to be added to the new Datasets Service and/or added in a higher level module or package in Pennsieve Go Core.

Included are some of the surrounding and necessary capabilities to deal with getting and (in some cases) creating:
- Dataset Status
- Data Use Agreements
- Organization Users (workspace membership)
- Contributors