### PR TITLE
fix unspecified license

### DIFF
--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -63,7 +63,7 @@ func (q *Queries) CreateDataset(ctx context.Context, p CreateDatasetParams) (*pg
 
 	statement := fmt.Sprintf("INSERT INTO datasets (name, node_id, state, description, automatically_process_packages," +
 		" status_id, license, tags, data_use_agreement_id)" +
-		" VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9);")
+		" VALUES($1, $2, $3, $4, $5, $6, NULLIF($7, ''), $8, $9);")
 
 	_, err = q.db.ExecContext(ctx, statement,
 		p.Name,

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -78,13 +78,14 @@ func TestDatasets(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
-		"Get Dataset by Name":         testGetDatasetByName,
-		"Create Dataset":              testCreateDataset,
-		"Add Owner to Dataset":        testAddOwnerToDataset,
-		"Add Viewer to Dataset":       testAddViewerToDataset,
-		"Add Editor to Dataset":       testAddEditorToDataset,
-		"Add Manager to Dataset":      testAddManagerToDataset,
-		"Unspecified License is Null": testUnspecifiedLicenseIsNull,
+		"Get Dataset by Name":          testGetDatasetByName,
+		"Create Dataset":               testCreateDataset,
+		"Add Owner to Dataset":         testAddOwnerToDataset,
+		"Add Viewer to Dataset":        testAddViewerToDataset,
+		"Add Editor to Dataset":        testAddEditorToDataset,
+		"Add Manager to Dataset":       testAddManagerToDataset,
+		"Unspecified License is Null":  testUnspecifiedLicenseIsNull,
+		"Empty String License Is Null": testEmptyStringLicenseIsNull,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := orgId
@@ -226,6 +227,30 @@ func testUnspecifiedLicenseIsNull(t *testing.T, store *SQLStore, orgId int) {
 	createDatasetParams := CreateDatasetParams{
 		Name:                         "Test Dataset - UnspecifiedLicenseIsNull",
 		Description:                  "Test Dataset - UnspecifiedLicenseIsNull",
+		Status:                       defaultDatasetStatus,
+		AutomaticallyProcessPackages: false,
+		Tags:                         nil,
+		DataUseAgreement:             defaultDataUseAgreement,
+	}
+	ds, err := store.CreateDataset(context.TODO(), createDatasetParams)
+	assert.NoError(t, err)
+	assert.Equal(t, createDatasetParams.Name, ds.Name)
+	assert.False(t, ds.License.Valid)
+}
+
+func testEmptyStringLicenseIsNull(t *testing.T, store *SQLStore, orgId int) {
+	var err error
+	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
+	if err != nil {
+		fmt.Errorf("testCreateDataset(): failed to get default dataset status")
+	}
+	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
+	if err != nil {
+		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
+	}
+	createDatasetParams := CreateDatasetParams{
+		Name:                         "Test Dataset - EmptyStringLicenseIsNull",
+		Description:                  "Test Dataset - EmptyStringLicenseIsNull",
 		Status:                       defaultDatasetStatus,
 		AutomaticallyProcessPackages: false,
 		License:                      "",

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -78,12 +78,13 @@ func TestDatasets(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
-		"Get Dataset by Name":    testGetDatasetByName,
-		"Create Dataset":         testCreateDataset,
-		"Add Owner to Dataset":   testAddOwnerToDataset,
-		"Add Viewer to Dataset":  testAddViewerToDataset,
-		"Add Editor to Dataset":  testAddEditorToDataset,
-		"Add Manager to Dataset": testAddManagerToDataset,
+		"Get Dataset by Name":         testGetDatasetByName,
+		"Create Dataset":              testCreateDataset,
+		"Add Owner to Dataset":        testAddOwnerToDataset,
+		"Add Viewer to Dataset":       testAddViewerToDataset,
+		"Add Editor to Dataset":       testAddEditorToDataset,
+		"Add Manager to Dataset":      testAddManagerToDataset,
+		"Unspecified License is Null": testUnspecifiedLicenseIsNull,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := orgId
@@ -115,7 +116,7 @@ func testCreateDataset(t *testing.T, store *SQLStore, orgId int) {
 		Description:                  "Test Dataset - CreateDataset",
 		Status:                       defaultDatasetStatus,
 		AutomaticallyProcessPackages: false,
-		License:                      "",
+		License:                      "Community Data License Agreement – Sharing",
 		Tags:                         nil,
 		DataUseAgreement:             defaultDataUseAgreement,
 	}
@@ -210,4 +211,29 @@ func testAddManagerToDataset(t *testing.T, store *SQLStore, orgId int) {
 		role,
 		expectedLabel,
 		expectedPermission)
+}
+
+func testUnspecifiedLicenseIsNull(t *testing.T, store *SQLStore, orgId int) {
+	var err error
+	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
+	if err != nil {
+		fmt.Errorf("testCreateDataset(): failed to get default dataset status")
+	}
+	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
+	if err != nil {
+		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
+	}
+	createDatasetParams := CreateDatasetParams{
+		Name:                         "Test Dataset - UnspecifiedLicenseIsNull",
+		Description:                  "Test Dataset - UnspecifiedLicenseIsNull",
+		Status:                       defaultDatasetStatus,
+		AutomaticallyProcessPackages: false,
+		License:                      "",
+		Tags:                         nil,
+		DataUseAgreement:             defaultDataUseAgreement,
+	}
+	ds, err := store.CreateDataset(context.TODO(), createDatasetParams)
+	assert.NoError(t, err)
+	assert.Equal(t, createDatasetParams.Name, ds.Name)
+	assert.False(t, ds.License.Valid)
 }


### PR DESCRIPTION
CreateDataset()
- when the License is either not specified, or is the empty string, then set the value to null in the datasets table.