### PR TITLE
Add ON CONFLICT to Files table inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Shared code for the Go services in Pennsieve
 1. Merge updates into the main branch
 2. Create a new tag in main and name the tag: vx.x.x following [semantic versioning](https://semver.org/).
 
-   e.g ```git tag -a 0.0.1 -m "Initial release"```
+   e.g ```git tag -a v0.0.1 -m "Initial release"```
 
    Given a version number MAJOR.MINOR.PATCH, increment the:
 
@@ -16,6 +16,6 @@ Shared code for the Go services in Pennsieve
 
 3. Push the tag to Gihub
 
-   eg. ```git push origin 0.0.1```
+   eg. ```git push origin v0.0.1```
 
 This will trigger Github Actions to create a new release with the same name.

--- a/pkg/queries/pgdb/files.go
+++ b/pkg/queries/pgdb/files.go
@@ -54,7 +54,7 @@ func (q *Queries) AddFiles(ctx context.Context, files []pgdb.FileParams) ([]pgdb
 
 	sqlInsert = sqlInsert +
 		strings.Join(inserts, ",") +
-		fmt.Sprintf("ON CONFLICT (uuid) DO UPDATE SET updated_at=EXCLUDED.updated_at RETURNING %s;", returnRows)
+		fmt.Sprintf("ON CONFLICT (uuid) DO UPDATE SET updated_at = EXCLUDED.updated_at WHERE files.s3_bucket = EXCLUDED.s3_bucket AND files.s3_key = EXCLUDED.s3_key RETURNING %s;", returnRows)
 
 	//prepare the statement
 	stmt, err := q.db.PrepareContext(ctx, sqlInsert)

--- a/pkg/queries/pgdb/files.go
+++ b/pkg/queries/pgdb/files.go
@@ -47,7 +47,8 @@ func (q *Queries) AddFiles(ctx context.Context, files []pgdb.FileParams) ([]pgdb
 	}
 
 	sqlInsert := "INSERT INTO files(package_id, name, file_type, s3_bucket, s3_key, " +
-		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES "
+		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES " +
+		"ON CONFLICT (uuid) DO UPDATE SET updated_at=EXCLUDED.updated_at"
 
 	returnRows := "id, package_id, name, file_type, s3_bucket, s3_key, " +
 		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at"

--- a/pkg/queries/pgdb/files.go
+++ b/pkg/queries/pgdb/files.go
@@ -47,13 +47,14 @@ func (q *Queries) AddFiles(ctx context.Context, files []pgdb.FileParams) ([]pgdb
 	}
 
 	sqlInsert := "INSERT INTO files(package_id, name, file_type, s3_bucket, s3_key, " +
-		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES " +
-		"ON CONFLICT (uuid) DO UPDATE SET updated_at=EXCLUDED.updated_at"
+		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES "
 
 	returnRows := "id, package_id, name, file_type, s3_bucket, s3_key, " +
 		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at"
 
-	sqlInsert = sqlInsert + strings.Join(inserts, ",") + fmt.Sprintf("RETURNING %s;", returnRows)
+	sqlInsert = sqlInsert +
+		strings.Join(inserts, ",") +
+		fmt.Sprintf("ON CONFLICT (uuid) DO UPDATE SET updated_at=EXCLUDED.updated_at RETURNING %s;", returnRows)
 
 	//prepare the statement
 	stmt, err := q.db.PrepareContext(ctx, sqlInsert)

--- a/pkg/queries/pgdb/files_test.go
+++ b/pkg/queries/pgdb/files_test.go
@@ -1,0 +1,152 @@
+package pgdb
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/fileInfo/fileType"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/fileInfo/objectType"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	"github.com/pennsieve/pennsieve-go-core/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFiles(t *testing.T) {
+	orgId := 3
+	db := testDB[orgId]
+	store := NewSQLStore(db)
+
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int, packageId int,
+	){
+		"AddFiles duplicate uuid":                    testAddFilesDuplicateUUID,
+		"AddFiles duplicate uuid, differing S3 keys": testAddFilesDuplicateUUIDDifferentS3Key,
+	} {
+
+		t.Run(scenario, func(t *testing.T) {
+			defer test.Truncate(t, db, orgId, "packages")
+			defer test.Truncate(t, db, orgId, "datasets")
+
+			datasetId := addTestDataset(db, "TestFiles Dataset")
+			packages, err := store.AddPackages(context.Background(),
+				test.GenerateTestPackages([]test.PackageParams{{Name: "test-package", ParentId: -1}}, int(datasetId)))
+			if err != nil {
+				assert.FailNow(t, "unable to set up test; error inserting package", err)
+			}
+			if len(packages) != 1 {
+				assert.FailNow(t, "unable to set up test; unexpected number of packages", packages)
+			}
+			packageId := int(packages[0].Id)
+
+			orgId := orgId
+			store := store
+			fn(t, store, orgId, packageId)
+		})
+	}
+}
+
+func testAddFilesDuplicateUUID(t *testing.T, store *SQLStore, orgId int, packageId int) {
+	defer test.Truncate(t, store.db, orgId, "files")
+
+	s3Bucket := "test-bucket"
+	s3Key := "test/s3/key/a1b2.edf"
+	uuid := uuid.Must(uuid.NewUUID())
+	files := []pgdb.FileParams{{
+		PackageId:  packageId,
+		Name:       "test-file",
+		FileType:   fileType.EDF,
+		S3Bucket:   s3Bucket,
+		S3Key:      s3Key,
+		ObjectType: objectType.Source,
+		Size:       1024,
+		CheckSum:   "",
+		Sha256:     "",
+		UUID:       uuid,
+	}}
+	var actualFileId string
+	actualFiles, err := store.AddFiles(context.Background(), files)
+	if assert.NoError(t, err) {
+		assert.Len(t, actualFiles, 1)
+		assert.Equal(t, s3Bucket, actualFiles[0].S3Bucket)
+		assert.Equal(t, s3Key, actualFiles[0].S3Key)
+		assert.Equal(t, uuid, actualFiles[0].UUID)
+		actualFileId = actualFiles[0].Id
+		assert.NotEmpty(t, actualFileId)
+	}
+	duplicateFiles, err := store.AddFiles(context.Background(), files)
+	if assert.NoError(t, err) {
+		assert.Len(t, duplicateFiles, 1)
+		assert.Equal(t, s3Bucket, duplicateFiles[0].S3Bucket)
+		assert.Equal(t, s3Key, duplicateFiles[0].S3Key)
+		assert.Equal(t, uuid, duplicateFiles[0].UUID)
+		assert.Equal(t, actualFileId, duplicateFiles[0].Id)
+	}
+}
+
+func testAddFilesDuplicateUUIDDifferentS3Key(t *testing.T, store *SQLStore, orgId int, packageId int) {
+	defer test.Truncate(t, store.db, orgId, "files")
+
+	s3Bucket := "test-bucket"
+	fileUUID := uuid.Must(uuid.NewUUID())
+	initialFile := pgdb.FileParams{
+		PackageId:  packageId,
+		Name:       "test-file",
+		FileType:   fileType.EDF,
+		S3Bucket:   s3Bucket,
+		S3Key:      "test/s3/key/a1b2.edf",
+		ObjectType: objectType.Source,
+		Size:       1024,
+		CheckSum:   "",
+		Sha256:     "",
+		UUID:       fileUUID,
+	}
+	var actualInitialFileId string
+	actualInitialFiles, err := store.AddFiles(context.Background(), []pgdb.FileParams{initialFile})
+	if assert.NoError(t, err) {
+		assert.Len(t, actualInitialFiles, 1)
+		assert.Equal(t, s3Bucket, actualInitialFiles[0].S3Bucket)
+		assert.Equal(t, initialFile.S3Key, actualInitialFiles[0].S3Key)
+		assert.Equal(t, fileUUID, actualInitialFiles[0].UUID)
+		actualInitialFileId = actualInitialFiles[0].Id
+		assert.NotEmpty(t, actualInitialFileId)
+	}
+
+	mistakeFile := pgdb.FileParams{
+		PackageId:  packageId,
+		Name:       "test-file",
+		FileType:   fileType.EDF,
+		S3Bucket:   s3Bucket,
+		S3Key:      "test/not/the/same/key/a1b2.edf",
+		ObjectType: objectType.Source,
+		Size:       1024,
+		CheckSum:   "",
+		Sha256:     "",
+		UUID:       fileUUID,
+	}
+	actualMistakeFiles, err := store.AddFiles(context.Background(), []pgdb.FileParams{mistakeFile})
+	if assert.NoError(t, err) {
+		assert.Empty(t, actualMistakeFiles)
+	}
+	var actualFileCount int
+	err = store.db.QueryRow("SELECT count(*) from files where package_id = $1", packageId).Scan(&actualFileCount)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, actualFileCount)
+	}
+
+	var actualPacakgeId int
+	var actualId, actualBucket, actualKey string
+	var actualUUID uuid.UUID
+	err = store.db.QueryRow("SELECT id, package_id, s3_bucket, s3_key, uuid from files where package_id = $1", packageId).Scan(
+		&actualId,
+		&actualPacakgeId,
+		&actualBucket,
+		&actualKey,
+		&actualUUID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, actualInitialFileId, actualId)
+		assert.Equal(t, actualPacakgeId, packageId)
+		assert.Equal(t, actualBucket, s3Bucket)
+		assert.Equal(t, actualKey, initialFile.S3Key)
+		assert.Equal(t, fileUUID, actualUUID)
+	}
+}

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -182,16 +182,18 @@ func addDataset(db *sql.DB) {
 
 }
 
-func addTestDataset(db *sql.DB, datasetName string) {
+func addTestDataset(db *sql.DB, datasetName string) int64 {
 	datasetNodeId := nodeId.NodeId(nodeId.DataSetCode)
 	datasetState := "READY"
 	datasetStatusId := 1
-	statement := fmt.Sprintf("INSERT INTO datasets (name, node_id, state, status_id) VALUES ('%s', '%s', '%s', %d);",
+	statement := fmt.Sprintf("INSERT INTO datasets (name, node_id, state, status_id) VALUES ('%s', '%s', '%s', %d) RETURNING id;",
 		datasetName, datasetNodeId, datasetState, datasetStatusId)
-	_, err := db.Exec(statement)
+	var datasetId int64
+	err := db.QueryRow(statement).Scan(&datasetId)
 	if err != nil {
 		log.Fatal(fmt.Sprintf("Unable to add dataset for test: %v", err))
 	}
+	return datasetId
 }
 
 // TestStore is the main Test Suite function for Packages.


### PR DESCRIPTION
PR adds an `ON CONFLICT` clause to the query used by `AddFiles()` to insert rows in the `files` table. The constraint in the conflict is the unique `uuid` column.

We have seen problems with upload-move possibly getting [duplicate create-object events from S3](https://repost.aws/knowledge-center/s3-duplicate-sqs-messages) and trying to insert the same file more than once.

The insert query has a `RETURNING` clause to return the newly inserted row. 

The `ON CONFLICT` clause in this PR is written so that if the row being inserted has the same uuid and S3 bucket & key, then the `updated_on` column will be updated and the resulting updated row will be returned.

But if the new row only matches on uuid and has a different S3 bucket or key, then `updated_on` is not updated and nothing is returned.

Part of ticket for [Handle Duplicate S3 Create Events](https://app.clickup.com/t/860qqy0ya).