### PR TITLE
Fix org id in token user lookup

### DIFF
--- a/pkg/queries/pgdb/tokens.go
+++ b/pkg/queries/pgdb/tokens.go
@@ -41,7 +41,7 @@ func (q *Queries) GetTokenByCognitoId(ctx context.Context, id string) (*pgdb.Tok
 // GetUserByCognitoId returns a Pennsieve User based on the cognito id in the token pool.
 func (q *Queries) GetUserByCognitoId(ctx context.Context, id string) (*pgdb.User, error) {
 
-	queryStr := "SELECT pennsieve.users.id, email, first_name, last_name, is_super_admin, preferred_org_id " +
+	queryStr := "SELECT pennsieve.users.id, email, first_name, last_name, is_super_admin, pennsieve.tokens.organization_id as preferred_org_id " +
 		"FROM pennsieve.users JOIN pennsieve.tokens ON pennsieve.tokens.user_id = pennsieve.users.id WHERE pennsieve.tokens.token=$1;"
 
 	var user pgdb.User

--- a/pkg/queries/pgdb/tokens_test.go
+++ b/pkg/queries/pgdb/tokens_test.go
@@ -1,0 +1,31 @@
+package pgdb
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTokens(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Get Token User by Cognito Id": testGetTokenUserByCognitoId,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := 0
+			store := NewSQLStore(testDB[orgId])
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func testGetTokenUserByCognitoId(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(2001)
+	organizationId := int64(1)
+	cognitoId := "00000000-1111-0000-2222-000000002001"
+	user, err := store.GetUserByCognitoId(context.TODO(), cognitoId)
+	assert.NoError(t, err)
+	assert.Equal(t, user.Id, userId)
+	assert.Equal(t, user.PreferredOrg, organizationId)
+}


### PR DESCRIPTION
When Integration Users are added to the platform, the following happens:
- an account is created in the Cognito Token Pool
- a Pennsieve User is created, the `preferred_org_id` is not set
- the Pennsieve User is added to the Organization
- a Pennsieve Token is created which links the Cognito Token Pool User to the Pennsieve User

The issue arises when the query to find a Token Pool User by their Cognito Id was passed to `Scan()` and the `preferred_org_id` was null (and the struct does not permit that value to be null) on the Pennsieve User. Returning an organization id is essential because it will be used by the Authorizer to generate an Organization Claim for the user.

The fix is to return the `organization_id` from the Pennsieve Token as the `preferred_org_id`. This seems adequate and correct because (1) an API Token is created for a specific user - organization tuple, (2) while an Integration User will not switch organizations, a real user may switch their preferred organization and a token should not be used to authorize outside the organization in which it was created.

Reproduced with added tests, observed the failure:
```
local_tests_1     | --- FAIL: TestTokens (0.01s)
local_tests_1     |     --- FAIL: TestTokens/Get_Token_User_by_Cognito_Id (0.01s)
local_tests_1     | panic: sql: Scan error on column index 5, name "preferred_org_id": converting NULL to int64 is unsupported [recovered]
local_tests_1     | 	panic: sql: Scan error on column index 5, name "preferred_org_id": converting NULL to int64 is unsupported
```