### PR TITLE
fix GetUserById failing when preferred_org_id is null

### DIFF
--- a/pkg/queries/pgdb/users.go
+++ b/pkg/queries/pgdb/users.go
@@ -11,7 +11,7 @@ import (
 //This function also returns the preferred org and whether the user is a super-admin.
 func (q *Queries) GetByCognitoId(ctx context.Context, id string) (*pgdb.User, error) {
 
-	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, preferred_org_id " +
+	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, COALESCE(preferred_org_id, -1) as preferred_org_id " +
 		"FROM pennsieve.users WHERE cognito_id=$1;"
 
 	var user pgdb.User
@@ -40,7 +40,7 @@ func (q *Queries) GetByCognitoId(ctx context.Context, id string) (*pgdb.User, er
 // This function also returns the preferred org and whether the user is a super-admin.
 func (q *Queries) GetUserById(ctx context.Context, id int64) (*pgdb.User, error) {
 
-	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, preferred_org_id " +
+	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, COALESCE(preferred_org_id, -1) as preferred_org_id " +
 		"FROM pennsieve.users WHERE id=$1;"
 
 	var user pgdb.User

--- a/pkg/queries/pgdb/users_test.go
+++ b/pkg/queries/pgdb/users_test.go
@@ -11,8 +11,9 @@ func TestUsers(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
-		"Get User by Id":         testGetUserByID,
-		"Get User by Cognito Id": testGetUserByCognitoId,
+		"Get User by Id":                     testGetUserByID,
+		"Get User by Cognito Id":             testGetUserByCognitoId,
+		"Get User By ID No Preferred Org Id": testGetUserByIDNullPreferredOrgId,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 0
@@ -33,6 +34,13 @@ func testGetUserByCognitoId(t *testing.T, store *SQLStore, orgId int) {
 	id := int64(1002)
 	cognitoId := "22222222-2222-2222-2222-222222222222"
 	user, err := store.GetByCognitoId(context.TODO(), cognitoId)
+	assert.NoError(t, err)
+	assert.Equal(t, user.Id, id)
+}
+
+func testGetUserByIDNullPreferredOrgId(t *testing.T, store *SQLStore, orgId int) {
+	id := int64(2001)
+	user, err := store.GetUserById(context.TODO(), id)
 	assert.NoError(t, err)
 	assert.Equal(t, user.Id, id)
 }


### PR DESCRIPTION
Fix:
- coalesce `preferred_org_id` to prevent failure on `Scan()` when value is null

downstream effects:
- `GetUserById()` is currently used by the **Upload Service V2**, and the **Publishing Service**
- neither appear to use `preferred_org_id` from the returned **User** record
- `GetByCognitoId()` is used by the new **Authorizer**
- the Authorizer will use `preferred_org_id` from the returned **User** record to generate Organization and Dataset claims, if the token does not have a `custom:organization_id` value
- for Token Pool users (authentication by API Key and Secret), the User `preferred_org_id` comes from the `pennsieve.tokens` table `organization_id` column
- for UserPool users (authentication by Username and Password), the User `preferred_org_id` comes from the `pennsieve.users` table `preferred_org_id` column

ToDo:
- [x] determine downstream effect of `preferred_org_id` value being -1