### PR TITLE
Feature/generate service token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pusher/pusher-http-go/v5 v5.1.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=

--- a/pkg/authorizer/claims.go
+++ b/pkg/authorizer/claims.go
@@ -1,6 +1,7 @@
 package authorizer
 
 import (
+	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer/models"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
@@ -9,6 +10,8 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/teamUser"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/user"
 	log "github.com/sirupsen/logrus"
+	"strconv"
+	"time"
 )
 
 // Claims is an object containing claims and user info
@@ -112,4 +115,14 @@ func IsPublisher(claims *Claims) bool {
 	}
 
 	return isPublisher
+}
+
+func GenerateServiceClaim(duration time.Duration) models.ServiceClaim {
+	issuedTime := time.Now().Unix()
+	expiresAt := issuedTime + duration.Milliseconds()/1000
+	return models.ServiceClaim{
+		Type:      "service_claim",
+		IssuedAt:  strconv.FormatInt(issuedTime, 10),
+		ExpiresAt: strconv.FormatInt(expiresAt, 10),
+	}
 }

--- a/pkg/authorizer/claims_test.go
+++ b/pkg/authorizer/claims_test.go
@@ -1,8 +1,15 @@
 package authorizer
 
 import (
+	"encoding/json"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/role"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 type ClaimResponse struct {
@@ -12,10 +19,13 @@ type ClaimResponse struct {
 func TestClaims(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T){
-		"Parse Claims":     testParseClaims,
-		"Is Publisher":     testIsPublisher,
-		"Is Not Publisher": testIsNotPublisher,
-		"No Team Claims":   testNoTeamClaims,
+		"Parse Claims":                        testParseClaims,
+		"Is Publisher":                        testIsPublisher,
+		"Is Not Publisher":                    testIsNotPublisher,
+		"No Team Claims":                      testNoTeamClaims,
+		"Generate a Service Claim":            testGenerateServiceClaim,
+		"Generate a Service Claim with roles": testGenerateServiceClaimWithRoles,
+		"Service Claim as Token":              testServiceClaimAsToken,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			fn(t)
@@ -107,4 +117,51 @@ func testNoTeamClaims(t *testing.T) {
 	assert.NotNil(t, claims.DatasetClaim)
 	assert.NotNil(t, claims.UserClaim)
 	assert.False(t, IsPublisher(claims))
+}
+
+func testGenerateServiceClaim(t *testing.T) {
+	claim := GenerateServiceClaim(5 * time.Minute)
+	assert.NotNil(t, claim)
+}
+
+func testGenerateServiceClaimWithRoles(t *testing.T) {
+	orgClaim := organization.Claim{
+		Role:            pgdb.Owner,
+		IntId:           367,
+		NodeId:          "N:organization:06c8002d-477a-45e9-ae0d-06f4b218628f",
+		EnabledFeatures: nil,
+	}
+	datasetClaim := dataset.Claim{
+		Role:   role.Owner,
+		NodeId: "N:dataset:ca645a17-fb55-4afd-aff8-7e0078b4523f",
+		IntId:  86,
+	}
+	claim := GenerateServiceClaim(5 * time.Minute).WithOrganizationClaim(orgClaim).WithDatasetClaim(datasetClaim)
+	assert.NotNil(t, claim)
+	data, err := json.Marshal(claim)
+	assert.NoError(t, err)
+	dataString := string(data)
+	fmt.Println(dataString)
+}
+
+func testServiceClaimAsToken(t *testing.T) {
+	orgClaim := organization.Claim{
+		Role:            pgdb.Owner,
+		IntId:           367,
+		NodeId:          "N:organization:06c8002d-477a-45e9-ae0d-06f4b218628f",
+		EnabledFeatures: nil,
+	}
+	datasetClaim := dataset.Claim{
+		Role:   role.Owner,
+		NodeId: "N:dataset:ca645a17-fb55-4afd-aff8-7e0078b4523f",
+		IntId:  86,
+	}
+	claim := GenerateServiceClaim(5 * time.Minute).WithOrganizationClaim(orgClaim).WithDatasetClaim(datasetClaim)
+	token, err := claim.AsToken("secret")
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	data, err := json.Marshal(token)
+	assert.NoError(t, err)
+	dataString := string(data)
+	fmt.Println(dataString)
 }

--- a/pkg/authorizer/models/models.go
+++ b/pkg/authorizer/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
 	"strconv"
@@ -25,20 +26,43 @@ type ServiceToken struct {
 	Value string `json:"value"`
 }
 
-func (c ServiceClaim) WithOrganizationClaim(claim organization.Claim) {
+func (c ServiceClaim) WithOrganizationClaim(claim organization.Claim) ServiceClaim {
 	c.Roles = append(c.Roles, ServiceRole{
 		Type:   "organization_role",
 		Id:     strconv.FormatInt(claim.IntId, 10),
 		NodeId: claim.NodeId,
 		Role:   claim.Role.AsOrganizationRole(),
 	})
+	return c
 }
 
-func (c ServiceClaim) WithDatasetClaim(claim dataset.Claim) {
+func (c ServiceClaim) WithDatasetClaim(claim dataset.Claim) ServiceClaim {
 	c.Roles = append(c.Roles, ServiceRole{
 		Type:   "dataset_role",
 		Id:     strconv.FormatInt(claim.IntId, 10),
 		NodeId: claim.NodeId,
 		Role:   strings.ToLower(claim.Role.String()),
 	})
+	return c
+}
+
+func (c ServiceClaim) AsToken(key string) (*ServiceToken, error) {
+	var (
+		err          error
+		secret       []byte
+		token        *jwt.Token
+		signedString string
+	)
+	token = jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iat":   c.IssuedAt,
+		"exp":   c.ExpiresAt,
+		"type":  c.Type,
+		"roles": c.Roles,
+	})
+	secret = []byte(key)
+	signedString, err = token.SignedString(secret)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceToken{Value: signedString}, nil
 }

--- a/pkg/authorizer/models/models.go
+++ b/pkg/authorizer/models/models.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
+	"strconv"
+	"strings"
+)
+
+type ServiceRole struct {
+	Type   string `json:"type"`
+	Id     string `json:"id"`
+	NodeId string `json:"node_id"`
+	Role   string `json:"role"`
+}
+
+type ServiceClaim struct {
+	Type      string        `json:"type"`
+	IssuedAt  string        `json:"iat"`
+	ExpiresAt string        `json:"exp"`
+	Roles     []ServiceRole `json:"roles"`
+}
+
+type ServiceToken struct {
+	Value string `json:"value"`
+}
+
+func (c ServiceClaim) WithOrganizationClaim(claim organization.Claim) {
+	c.Roles = append(c.Roles, ServiceRole{
+		Type:   "organization_role",
+		Id:     strconv.FormatInt(claim.IntId, 10),
+		NodeId: claim.NodeId,
+		Role:   claim.Role.AsOrganizationRole(),
+	})
+}
+
+func (c ServiceClaim) WithDatasetClaim(claim dataset.Claim) {
+	c.Roles = append(c.Roles, ServiceRole{
+		Type:   "dataset_role",
+		Id:     strconv.FormatInt(claim.IntId, 10),
+		NodeId: claim.NodeId,
+		Role:   strings.ToLower(claim.Role.String()),
+	})
+}

--- a/pkg/authorizer/models/models.go
+++ b/pkg/authorizer/models/models.go
@@ -31,7 +31,7 @@ func (c ServiceClaim) WithOrganizationClaim(claim organization.Claim) ServiceCla
 		Type:   "organization_role",
 		Id:     strconv.FormatInt(claim.IntId, 10),
 		NodeId: claim.NodeId,
-		Role:   claim.Role.AsOrganizationRole(),
+		Role:   claim.Role.AsRoleString(),
 	})
 	return c
 }

--- a/pkg/models/pgdb/organizationUserTable.go
+++ b/pkg/models/pgdb/organizationUserTable.go
@@ -37,6 +37,32 @@ func (s DbPermission) String() string {
 	return "NoPermission"
 }
 
+func (s DbPermission) AsOrganizationRole() string {
+	switch s {
+	case NoPermission:
+		return "none"
+	case Guest:
+		return "guest"
+	case Read:
+
+		return "collaborator"
+	case Write:
+
+		return "collaborator"
+	case Delete:
+
+		return "collaborator"
+	case Administer:
+
+		return "administrator"
+	case Owner:
+
+		return "owner"
+	default:
+		return "none"
+	}
+}
+
 type OrganizationUser struct {
 	OrganizationId int64        `json:"organization_id"`
 	UserId         int64        `json:"user_id"`

--- a/pkg/models/pgdb/organizationUserTable.go
+++ b/pkg/models/pgdb/organizationUserTable.go
@@ -1,6 +1,7 @@
 package pgdb
 
 import (
+	"strings"
 	"time"
 )
 
@@ -37,7 +38,24 @@ func (s DbPermission) String() string {
 	return "NoPermission"
 }
 
-func (s DbPermission) AsOrganizationRole() string {
+func FromRole(role string) DbPermission {
+	switch strings.ToLower(role) {
+	case "guest":
+		return Guest
+	case "viewer":
+		return Read
+	case "editor":
+		return Delete
+	case "manager":
+		return Administer
+	case "owner":
+		return Owner
+	default:
+		return NoPermission
+	}
+}
+
+func (s DbPermission) AsRoleString() string {
 	switch s {
 	case NoPermission:
 		return "none"
@@ -45,16 +63,16 @@ func (s DbPermission) AsOrganizationRole() string {
 		return "guest"
 	case Read:
 
-		return "collaborator"
+		return "viewer"
 	case Write:
 
-		return "collaborator"
+		return "editor"
 	case Delete:
 
-		return "collaborator"
+		return "editor"
 	case Administer:
 
-		return "administrator"
+		return "manager"
 	case Owner:
 
 		return "owner"


### PR DESCRIPTION
Adds the ability to generate a Service Token in the Pennsieve Go Core library.

Service Tokens are used when one API service invokes the API endpoint of another service. The Service Token asserts that the service is acting on behalf of an Organization owner and/or a Dataset Owner. 

Service Tokens are used in several places on the Pennsieve platform, including (but not limited to):
- obtaining and updating DOIs
- obtaining Model information at the initiation of publishing
- initial and final steps of dataset publication
- notifying the Pennsieve platform that publication has completed

The mapping of `DbPermission` to a string representation of Role, and the reverse mapping now more closely follows this Pennsieve API Scala code:
```scala
  def fromRole(role: Option[Role]): DBPermission = role match {
    case Some(Role.Owner) => DBPermission.Owner
    case Some(Role.Manager) => DBPermission.Administer
    case Some(Role.Editor) => DBPermission.Delete
    case Some(Role.Viewer) => DBPermission.Read
    case Some(Role.Guest) => DBPermission.Guest
    case None => DBPermission.NoPermission
  }
```

Notes:   
1. This is a rather simplistic implementation following some inspiration from the Python and Scala packages in the [auth-middleware](https://github.com/Pennsieve/auth-middleware) repo. It is a much slimmer implementation, which we may want to revisit to make this a more prominent, robust and feature-rich Go package for Pennsieve.
2. There is a small (weird) gap in mapping `DbPermission` to `Role`, and then `Role` to `DbPermission` because there is not a complete 1-to-1 relationship; **write** and **delete** both map the the *Editor* role. If a user has **write** permission this maps to *Editor*, and then *Editor* will map to **delete** permission. This transformation flow effectively elevates a user with **write** permission to **delete** permission. At this point of the Pennsieve Go Core implementation, I think this is probably OK. We should revisit this in the future and shore up the concepts of `DbPermission` and `Role` to be more complete.