### PR TITLE
Feature/dataset release capabilities

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -58,7 +58,7 @@ services:
       - core-tests
 
   pennsievedb:
-    image: pennsieve/pennsievedb:V20240710150900-seed
+    image: pennsieve/pennsievedb:V20240823134600-seed
     restart: always
     ports:
       - "5432:5432"
@@ -66,7 +66,7 @@ services:
       - core-tests
 
   pennsievedb-ci:
-    image: pennsieve/pennsievedb:V20240710150900-seed
+    image: pennsieve/pennsievedb:V20240823134600-seed
     restart: always
     networks:
       - core-tests

--- a/pkg/models/pgdb/datasetTable.go
+++ b/pkg/models/pgdb/datasetTable.go
@@ -92,17 +92,19 @@ type DatasetContributor struct {
 }
 
 type DatasetRelease struct {
-	Id          int64          `json:"id"`
-	DatasetId   int64          `json:"dataset_id"`
-	Origin      string         `json:"origin"`
-	Url         string         `json:"url"`
-	Label       sql.NullString `json:"label"`
-	Marker      sql.NullString `json:"marker"`
-	Properties  Properties     `json:"properties"`
-	Tags        Tags           `json:"tags"`
-	ReleaseDate sql.NullTime   `json:"release_date"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
+	Id               int64          `json:"id"`
+	DatasetId        int64          `json:"dataset_id"`
+	Origin           string         `json:"origin"`
+	Url              string         `json:"url"`
+	Label            sql.NullString `json:"label"`
+	Marker           sql.NullString `json:"marker"`
+	Properties       Properties     `json:"properties"`
+	Tags             Tags           `json:"tags"`
+	ReleaseDate      sql.NullTime   `json:"release_date"`
+	ReleaseStatus    string         `json:"release_status"`
+	PublishingStatus string         `json:"publishing_status"`
+	CreatedAt        time.Time      `json:"created_at"`
+	UpdatedAt        time.Time      `json:"updated_at"`
 }
 
 type DatasetReleaseDTO struct {

--- a/pkg/queries/pgdb/datasetRelease.go
+++ b/pkg/queries/pgdb/datasetRelease.go
@@ -1,0 +1,93 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+)
+
+func (q *Queries) AddDatasetRelease(ctx context.Context, release pgdb.DatasetRelease) (*pgdb.DatasetRelease, error) {
+	statement := "INSERT INTO dataset_release (dataset_id, origin, url, label, marker, release_date) VALUES ($1, $2, $3, $4, $5, $6) returning id;"
+
+	//result, err := q.db.ExecContext(ctx, statement,
+	//	release.DatasetId,
+	//	release.Origin,
+	//	release.Url,
+	//	release.Label,
+	//	release.Marker,
+	//	release.ReleaseDate,
+	//)
+
+	var id int64
+	err := q.db.QueryRowContext(ctx,
+		statement,
+		release.DatasetId,
+		release.Origin,
+		release.Url,
+		release.Label,
+		release.Marker,
+		release.ReleaseDate,
+	).Scan(&id)
+
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("database error on insert: %v", err))
+	}
+
+	return q.GetDatasetReleaseById(ctx, id)
+}
+
+func (q *Queries) UpdateDatasetRelease(ctx context.Context, release pgdb.DatasetRelease) (*pgdb.DatasetRelease, error) {
+	statement := "UPDATE dataset_release SET label=$1, marker=$2, release_date=$3 WHERE id=$4"
+	_, err := q.db.ExecContext(ctx, statement,
+		release.Label,
+		release.Marker,
+		release.ReleaseDate,
+		release.Id,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("database error on update: %v", err))
+	}
+
+	return q.GetDatasetReleaseById(ctx, release.Id)
+}
+
+func (q *Queries) GetDatasetReleaseById(ctx context.Context, id int64) (*pgdb.DatasetRelease, error) {
+	predicate := fmt.Sprintf("id = %d", id)
+	return q.getDatasetRelease(ctx, predicate)
+}
+
+func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, label string, marker string) (*pgdb.DatasetRelease, error) {
+	predicate := fmt.Sprintf("dataset_id = %d AND label = '%s' AND marker = '%s'", datasetId, label, marker)
+	return q.getDatasetRelease(ctx, predicate)
+}
+
+func (q *Queries) getDatasetRelease(ctx context.Context, predicate string) (*pgdb.DatasetRelease, error) {
+	query := fmt.Sprintf("SELECT id, dataset_id, origin, url, label, marker, release_date, created_at, updated_at "+
+		"FROM dataset_release WHERE %s;", predicate)
+
+	var datasetRelease pgdb.DatasetRelease
+	row := q.db.QueryRowContext(ctx, query)
+	err := row.Scan(
+		&datasetRelease.Id,
+		&datasetRelease.DatasetId,
+		&datasetRelease.Origin,
+		&datasetRelease.Url,
+		&datasetRelease.Label,
+		&datasetRelease.Marker,
+		&datasetRelease.ReleaseDate,
+		&datasetRelease.CreatedAt,
+		&datasetRelease.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, &DatasetReleaseNotFoundError{fmt.Sprintf("dataset release not found where %s", predicate)}
+		} else {
+			return nil, fmt.Errorf(fmt.Sprintf("database error on query: %v", err))
+		}
+	}
+
+	return &datasetRelease, nil
+}

--- a/pkg/queries/pgdb/datasetRelease.go
+++ b/pkg/queries/pgdb/datasetRelease.go
@@ -8,7 +8,9 @@ import (
 )
 
 func (q *Queries) AddDatasetRelease(ctx context.Context, release pgdb.DatasetRelease) (*pgdb.DatasetRelease, error) {
-	statement := "INSERT INTO dataset_release (dataset_id, origin, url, label, marker, release_date) VALUES ($1, $2, $3, $4, $5, $6) returning id;"
+	statement := "INSERT INTO dataset_release " +
+		"(dataset_id, origin, url, label, marker, release_date, release_status, publishing_status) " +
+		"VALUES ($1, $2, $3, $4, $5, $6, $7, $8) returning id;"
 
 	//result, err := q.db.ExecContext(ctx, statement,
 	//	release.DatasetId,
@@ -28,6 +30,8 @@ func (q *Queries) AddDatasetRelease(ctx context.Context, release pgdb.DatasetRel
 		release.Label,
 		release.Marker,
 		release.ReleaseDate,
+		release.ReleaseStatus,
+		release.PublishingStatus,
 	).Scan(&id)
 
 	if err != nil {
@@ -38,11 +42,13 @@ func (q *Queries) AddDatasetRelease(ctx context.Context, release pgdb.DatasetRel
 }
 
 func (q *Queries) UpdateDatasetRelease(ctx context.Context, release pgdb.DatasetRelease) (*pgdb.DatasetRelease, error) {
-	statement := "UPDATE dataset_release SET label=$1, marker=$2, release_date=$3 WHERE id=$4"
+	statement := "UPDATE dataset_release SET label=$1, marker=$2, release_date=$3, release_status=$4, publishing_status=$5 WHERE id=$6;"
 	_, err := q.db.ExecContext(ctx, statement,
 		release.Label,
 		release.Marker,
 		release.ReleaseDate,
+		release.ReleaseStatus,
+		release.PublishingStatus,
 		release.Id,
 	)
 
@@ -64,8 +70,9 @@ func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, label 
 }
 
 func (q *Queries) getDatasetRelease(ctx context.Context, predicate string) (*pgdb.DatasetRelease, error) {
-	query := fmt.Sprintf("SELECT id, dataset_id, origin, url, label, marker, release_date, created_at, updated_at "+
-		"FROM dataset_release WHERE %s;", predicate)
+	query := fmt.Sprintf(
+		"SELECT id, dataset_id, origin, url, label, marker, release_date, release_status, publishing_status, created_at, updated_at "+
+			"FROM dataset_release WHERE %s;", predicate)
 
 	var datasetRelease pgdb.DatasetRelease
 	row := q.db.QueryRowContext(ctx, query)
@@ -77,6 +84,8 @@ func (q *Queries) getDatasetRelease(ctx context.Context, predicate string) (*pgd
 		&datasetRelease.Label,
 		&datasetRelease.Marker,
 		&datasetRelease.ReleaseDate,
+		&datasetRelease.ReleaseStatus,
+		&datasetRelease.PublishingStatus,
 		&datasetRelease.CreatedAt,
 		&datasetRelease.UpdatedAt,
 	)

--- a/pkg/queries/pgdb/datasetRelease_test.go
+++ b/pkg/queries/pgdb/datasetRelease_test.go
@@ -1,0 +1,198 @@
+package pgdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset/datasetType"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestDatasetRelease(t *testing.T) {
+	orgId := 3
+	db := testDB[orgId]
+	store := NewSQLStore(db)
+
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore, orgId int,
+	){
+		"Add Dataset Release":       testAddDatasetRelease,
+		"Get Dataset Release":       testGetDatasetRelease,
+		"Get Dataset Release by Id": testGetDatasetReleaseById,
+		"Update Dataset Release":    testUpdateDatasetRelease,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			orgId := orgId
+			store := store
+			fn(t, store, orgId)
+		})
+	}
+}
+
+func deleteDataset(store *SQLStore, datasetId int64) {
+	statement := fmt.Sprintf("DELETE FROM datasets WHERE id = $1")
+	_, err := store.db.ExecContext(context.TODO(),
+		statement,
+		datasetId,
+	)
+
+	if err != nil {
+		fmt.Printf(fmt.Sprintf("deleteDataset() database error: %v", err))
+	}
+}
+
+func addDatasetTypeRelease(store *SQLStore, orgId int, name string) int64 {
+	var err error
+	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
+	if err != nil {
+		panic("testCreateDataset(): failed to get default dataset status")
+	}
+	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
+	if err != nil {
+		panic("testCreateDataset(): failed to get default data use agreement")
+	}
+	createDatasetParams := CreateDatasetParams{
+		Name:                         name,
+		Description:                  name,
+		Status:                       defaultDatasetStatus,
+		AutomaticallyProcessPackages: false,
+		License:                      "Community Data License Agreement – Sharing",
+		Tags:                         nil,
+		DataUseAgreement:             defaultDataUseAgreement,
+		Type:                         datasetType.Release,
+	}
+
+	dataset, err := store.CreateDataset(context.TODO(), createDatasetParams)
+	if err != nil {
+		panic(err)
+	}
+	return dataset.Id
+}
+
+func testAddDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
+	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 01")
+
+	input := pgdb.DatasetRelease{
+		DatasetId:   datasetId,
+		Origin:      "GitHub",
+		Url:         "https://github.com/pennsieve/pennsieve",
+		Label:       sql.NullString{},
+		Marker:      sql.NullString{},
+		Properties:  nil,
+		Tags:        nil,
+		ReleaseDate: sql.NullTime{},
+	}
+
+	output, err := store.AddDatasetRelease(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, output.DatasetId)
+	deleteDataset(store, datasetId)
+}
+
+func testGetDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
+	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 02")
+
+	label := "v1.0.0"
+	marker := "0123456"
+
+	input := pgdb.DatasetRelease{
+		DatasetId:   datasetId,
+		Origin:      "GitHub",
+		Url:         "https://github.com/pennsieve/pennsieve",
+		Label:       sql.NullString{Valid: true, String: label},
+		Marker:      sql.NullString{Valid: true, String: marker},
+		Properties:  nil,
+		Tags:        nil,
+		ReleaseDate: sql.NullTime{},
+	}
+
+	output, err := store.AddDatasetRelease(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, output.DatasetId)
+
+	release, err := store.GetDatasetRelease(context.TODO(), output.DatasetId, label, marker)
+	assert.NoError(t, err)
+	assert.True(t, release.Label.Valid)
+	assert.Equal(t, label, release.Label.String)
+	assert.True(t, release.Marker.Valid)
+	assert.Equal(t, marker, release.Marker.String)
+	deleteDataset(store, datasetId)
+}
+
+func testGetDatasetReleaseById(t *testing.T, store *SQLStore, orgId int) {
+	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 03")
+
+	label := "v2.0.0"
+	marker := "1234567"
+
+	input := pgdb.DatasetRelease{
+		DatasetId:   datasetId,
+		Origin:      "GitHub",
+		Url:         "https://github.com/pennsieve/pennsieve",
+		Label:       sql.NullString{Valid: true, String: label},
+		Marker:      sql.NullString{Valid: true, String: marker},
+		Properties:  nil,
+		Tags:        nil,
+		ReleaseDate: sql.NullTime{},
+	}
+
+	output, err := store.AddDatasetRelease(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, output.DatasetId)
+	assert.True(t, output.Id > 0)
+
+	release, err := store.GetDatasetReleaseById(context.TODO(), output.Id)
+	assert.NoError(t, err)
+	assert.True(t, release.Label.Valid)
+	assert.Equal(t, label, release.Label.String)
+	assert.True(t, release.Marker.Valid)
+	assert.Equal(t, marker, release.Marker.String)
+	deleteDataset(store, datasetId)
+}
+
+func testUpdateDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
+	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 04")
+
+	input := pgdb.DatasetRelease{
+		DatasetId:   datasetId,
+		Origin:      "GitHub",
+		Url:         "https://github.com/pennsieve/pennsieve",
+		Label:       sql.NullString{},
+		Marker:      sql.NullString{},
+		Properties:  nil,
+		Tags:        nil,
+		ReleaseDate: sql.NullTime{},
+	}
+
+	output, err := store.AddDatasetRelease(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, output.DatasetId)
+
+	label := "v4.0.0"
+	marker := "1010101"
+	releaseDate := time.Date(2024, time.August, 27, 18, 32, 25, 0, time.UTC)
+
+	update := pgdb.DatasetRelease{
+		Id:          output.Id,
+		DatasetId:   datasetId,
+		Origin:      "GitHub",
+		Url:         "https://github.com/pennsieve/pennsieve",
+		Label:       sql.NullString{Valid: true, String: label},
+		Marker:      sql.NullString{Valid: true, String: marker},
+		Properties:  nil,
+		Tags:        nil,
+		ReleaseDate: sql.NullTime{Valid: true, Time: releaseDate},
+	}
+
+	updated, err := store.UpdateDatasetRelease(context.TODO(), update)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, updated.DatasetId)
+	assert.Equal(t, output.Id, updated.Id)
+	assert.Equal(t, label, updated.Label.String)
+	assert.Equal(t, marker, updated.Marker.String)
+	assert.True(t, releaseDate.Equal(updated.ReleaseDate.Time))
+	deleteDataset(store, datasetId)
+}

--- a/pkg/queries/pgdb/datasetRelease_test.go
+++ b/pkg/queries/pgdb/datasetRelease_test.go
@@ -23,6 +23,8 @@ func TestDatasetRelease(t *testing.T) {
 		"Get Dataset Release":       testGetDatasetRelease,
 		"Get Dataset Release by Id": testGetDatasetReleaseById,
 		"Update Dataset Release":    testUpdateDatasetRelease,
+		"Update Release Status":     testUpdateReleaseStatus,
+		"Update Publishing Status":  testUpdatePublishingStatus,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := orgId
@@ -76,14 +78,16 @@ func testAddDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
 	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 01")
 
 	input := pgdb.DatasetRelease{
-		DatasetId:   datasetId,
-		Origin:      "GitHub",
-		Url:         "https://github.com/pennsieve/pennsieve",
-		Label:       sql.NullString{},
-		Marker:      sql.NullString{},
-		Properties:  nil,
-		Tags:        nil,
-		ReleaseDate: sql.NullTime{},
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{},
+		Marker:           sql.NullString{},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{},
+		ReleaseStatus:    "created",
+		PublishingStatus: "initial",
 	}
 
 	output, err := store.AddDatasetRelease(context.TODO(), input)
@@ -99,14 +103,16 @@ func testGetDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
 	marker := "0123456"
 
 	input := pgdb.DatasetRelease{
-		DatasetId:   datasetId,
-		Origin:      "GitHub",
-		Url:         "https://github.com/pennsieve/pennsieve",
-		Label:       sql.NullString{Valid: true, String: label},
-		Marker:      sql.NullString{Valid: true, String: marker},
-		Properties:  nil,
-		Tags:        nil,
-		ReleaseDate: sql.NullTime{},
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{Valid: true, String: label},
+		Marker:           sql.NullString{Valid: true, String: marker},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{},
+		ReleaseStatus:    "created",
+		PublishingStatus: "initial",
 	}
 
 	output, err := store.AddDatasetRelease(context.TODO(), input)
@@ -129,14 +135,16 @@ func testGetDatasetReleaseById(t *testing.T, store *SQLStore, orgId int) {
 	marker := "1234567"
 
 	input := pgdb.DatasetRelease{
-		DatasetId:   datasetId,
-		Origin:      "GitHub",
-		Url:         "https://github.com/pennsieve/pennsieve",
-		Label:       sql.NullString{Valid: true, String: label},
-		Marker:      sql.NullString{Valid: true, String: marker},
-		Properties:  nil,
-		Tags:        nil,
-		ReleaseDate: sql.NullTime{},
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{Valid: true, String: label},
+		Marker:           sql.NullString{Valid: true, String: marker},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{},
+		ReleaseStatus:    "created",
+		PublishingStatus: "initial",
 	}
 
 	output, err := store.AddDatasetRelease(context.TODO(), input)
@@ -157,14 +165,16 @@ func testUpdateDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
 	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 04")
 
 	input := pgdb.DatasetRelease{
-		DatasetId:   datasetId,
-		Origin:      "GitHub",
-		Url:         "https://github.com/pennsieve/pennsieve",
-		Label:       sql.NullString{},
-		Marker:      sql.NullString{},
-		Properties:  nil,
-		Tags:        nil,
-		ReleaseDate: sql.NullTime{},
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{},
+		Marker:           sql.NullString{},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{},
+		ReleaseStatus:    "created",
+		PublishingStatus: "initial",
 	}
 
 	output, err := store.AddDatasetRelease(context.TODO(), input)
@@ -176,15 +186,17 @@ func testUpdateDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
 	releaseDate := time.Date(2024, time.August, 27, 18, 32, 25, 0, time.UTC)
 
 	update := pgdb.DatasetRelease{
-		Id:          output.Id,
-		DatasetId:   datasetId,
-		Origin:      "GitHub",
-		Url:         "https://github.com/pennsieve/pennsieve",
-		Label:       sql.NullString{Valid: true, String: label},
-		Marker:      sql.NullString{Valid: true, String: marker},
-		Properties:  nil,
-		Tags:        nil,
-		ReleaseDate: sql.NullTime{Valid: true, Time: releaseDate},
+		Id:               output.Id,
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{Valid: true, String: label},
+		Marker:           sql.NullString{Valid: true, String: marker},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{Valid: true, Time: releaseDate},
+		ReleaseStatus:    "created",
+		PublishingStatus: "initial",
 	}
 
 	updated, err := store.UpdateDatasetRelease(context.TODO(), update)
@@ -194,5 +206,110 @@ func testUpdateDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
 	assert.Equal(t, label, updated.Label.String)
 	assert.Equal(t, marker, updated.Marker.String)
 	assert.True(t, releaseDate.Equal(updated.ReleaseDate.Time))
+	deleteDataset(store, datasetId)
+}
+
+func testUpdateReleaseStatus(t *testing.T, store *SQLStore, orgId int) {
+	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 05")
+
+	initialReleaseStatus := "prerelease"
+	input := pgdb.DatasetRelease{
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{},
+		Marker:           sql.NullString{},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{},
+		ReleaseStatus:    initialReleaseStatus,
+		PublishingStatus: "initial",
+	}
+
+	output, err := store.AddDatasetRelease(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, output.DatasetId)
+
+	label := "v4.0.0"
+	marker := "1010101"
+	releaseDate := time.Date(2024, time.August, 27, 18, 32, 25, 0, time.UTC)
+
+	updatedReleaseStatus := "published"
+	update := pgdb.DatasetRelease{
+		Id:               output.Id,
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{Valid: true, String: label},
+		Marker:           sql.NullString{Valid: true, String: marker},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{Valid: true, Time: releaseDate},
+		ReleaseStatus:    updatedReleaseStatus,
+		PublishingStatus: "initial",
+	}
+
+	updated, err := store.UpdateDatasetRelease(context.TODO(), update)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, updated.DatasetId)
+	assert.Equal(t, output.Id, updated.Id)
+	assert.Equal(t, label, updated.Label.String)
+	assert.Equal(t, marker, updated.Marker.String)
+	assert.True(t, releaseDate.Equal(updated.ReleaseDate.Time))
+	assert.Equal(t, updatedReleaseStatus, updated.ReleaseStatus)
+	deleteDataset(store, datasetId)
+}
+
+func testUpdatePublishingStatus(t *testing.T, store *SQLStore, orgId int) {
+	datasetId := addDatasetTypeRelease(store, orgId, "Test Dataset Release - 06")
+
+	initialReleaseStatus := "created"
+	initialPublishingStatus := "initial"
+	input := pgdb.DatasetRelease{
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{},
+		Marker:           sql.NullString{},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{},
+		ReleaseStatus:    initialReleaseStatus,
+		PublishingStatus: initialPublishingStatus,
+	}
+
+	output, err := store.AddDatasetRelease(context.TODO(), input)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, output.DatasetId)
+
+	label := "v4.0.0"
+	marker := "1010101"
+	releaseDate := time.Date(2024, time.August, 27, 18, 32, 25, 0, time.UTC)
+
+	updatedReleaseStatus := "created"
+	updatedPublishingStatus := "succeeded"
+	update := pgdb.DatasetRelease{
+		Id:               output.Id,
+		DatasetId:        datasetId,
+		Origin:           "GitHub",
+		Url:              "https://github.com/pennsieve/pennsieve",
+		Label:            sql.NullString{Valid: true, String: label},
+		Marker:           sql.NullString{Valid: true, String: marker},
+		Properties:       nil,
+		Tags:             nil,
+		ReleaseDate:      sql.NullTime{Valid: true, Time: releaseDate},
+		ReleaseStatus:    updatedReleaseStatus,
+		PublishingStatus: updatedPublishingStatus,
+	}
+
+	updated, err := store.UpdateDatasetRelease(context.TODO(), update)
+	assert.NoError(t, err)
+	assert.Equal(t, datasetId, updated.DatasetId)
+	assert.Equal(t, output.Id, updated.Id)
+	assert.Equal(t, label, updated.Label.String)
+	assert.Equal(t, marker, updated.Marker.String)
+	assert.True(t, releaseDate.Equal(updated.ReleaseDate.Time))
+	assert.Equal(t, updatedReleaseStatus, updated.ReleaseStatus)
+	assert.Equal(t, updatedPublishingStatus, updated.PublishingStatus)
 	deleteDataset(store, datasetId)
 }

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -170,6 +170,16 @@ func (q *Queries) CreateDatasetTypeRelease(ctx context.Context, p CreateDatasetP
 	}, nil
 }
 
+// GetDatasetById will query workspace datasets by name and return one if found.
+func (q *Queries) GetDatasetById(ctx context.Context, id int64) (*pgdb.Dataset, error) {
+	query := fmt.Sprintf("SELECT id, name, state, description, updated_at, created_at, node_id,"+
+		" permission_bit, type, role, status, automatically_process_packages, license, tags, contributors,"+
+		" banner_id, readme_id, status_id, publication_status_id, size, etag, data_use_agreement_id, changelog_id"+
+		" FROM datasets WHERE id=%d;", id)
+	row := q.db.QueryRowContext(ctx, query)
+	return scanDataset(row)
+}
+
 // GetDatasetByName will query workspace datasets by name and return one if found.
 func (q *Queries) GetDatasetByName(ctx context.Context, name string) (*pgdb.Dataset, error) {
 	query := fmt.Sprintf("SELECT id, name, state, description, updated_at, created_at, node_id,"+

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -110,35 +110,6 @@ func (q *Queries) CreateDataset(ctx context.Context, p CreateDatasetParams) (*pg
 	return dataset, nil
 }
 
-func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, label string, marker string) (*pgdb.DatasetRelease, error) {
-	query := "SELECT id, dataset_id, origin, url, label, marker, release_date, created_at, updated_at " +
-		"FROM dataset_release WHERE dataset_id = $1 AND label = $2 AND marker = $3"
-
-	var datasetRelease pgdb.DatasetRelease
-	row := q.db.QueryRowContext(ctx, query, datasetId, label, marker)
-	err := row.Scan(
-		&datasetRelease.Id,
-		&datasetRelease.DatasetId,
-		&datasetRelease.Origin,
-		&datasetRelease.Url,
-		&datasetRelease.Label,
-		&datasetRelease.Marker,
-		&datasetRelease.ReleaseDate,
-		&datasetRelease.CreatedAt,
-		&datasetRelease.UpdatedAt,
-	)
-
-	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil, &DatasetReleaseNotFoundError{fmt.Sprintf("dataset release not found for datasetId %d label %s marker %s", datasetId, label, marker)}
-		} else {
-			return nil, fmt.Errorf(fmt.Sprintf("database error on query: %v", err))
-		}
-	}
-
-	return &datasetRelease, nil
-}
-
 // GetDatasetById will query workspace datasets by name and return one if found.
 func (q *Queries) GetDatasetById(ctx context.Context, id int64) (*pgdb.Dataset, error) {
 	return q.getDataset(ctx, fmt.Sprintf("id=%d", id))

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -139,37 +139,6 @@ func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, origin
 	return &datasetRelease, nil
 }
 
-func (q *Queries) CreateDatasetTypeRelease(ctx context.Context, p CreateDatasetParams, origin string, url string) (*pgdb.DatasetReleaseDTO, error) {
-	// first create the dataset
-	dataset, err := q.CreateDataset(ctx, p)
-	if err != nil {
-		return nil, err
-	}
-
-	// then create the dataset_release
-	statement := fmt.Sprintf("INSERT INTO dataset_release " +
-		"(dataset_id, origin, url)" +
-		" VALUES($1, $2, $3);")
-
-	_, err = q.db.ExecContext(ctx, statement, dataset.Id, origin, url)
-
-	if err != nil {
-		return nil, fmt.Errorf(fmt.Sprintf("database error on insert: %v", err))
-	}
-
-	// retrieve the dataset_release
-	release, err := q.GetDatasetRelease(ctx, dataset.Id, origin, url)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &pgdb.DatasetReleaseDTO{
-		Dataset: *dataset,
-		Release: *release,
-	}, nil
-}
-
 // GetDatasetById will query workspace datasets by name and return one if found.
 func (q *Queries) GetDatasetById(ctx context.Context, id int64) (*pgdb.Dataset, error) {
 	query := fmt.Sprintf("SELECT id, name, state, description, updated_at, created_at, node_id,"+

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -141,22 +141,17 @@ func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, origin
 
 // GetDatasetById will query workspace datasets by name and return one if found.
 func (q *Queries) GetDatasetById(ctx context.Context, id int64) (*pgdb.Dataset, error) {
-	query := fmt.Sprintf("SELECT id, name, state, description, updated_at, created_at, node_id,"+
-		" permission_bit, type, role, status, automatically_process_packages, license, tags, contributors,"+
-		" banner_id, readme_id, status_id, publication_status_id, size, etag, data_use_agreement_id, changelog_id"+
-		" FROM datasets WHERE id=%d;", id)
-	row := q.db.QueryRowContext(ctx, query)
-	return scanDataset(row)
+	return q.getDataset(ctx, fmt.Sprintf("id=%d", id))
+}
+
+// GetDatasetByNodeId will query workspace datasets by name and return one if found.
+func (q *Queries) GetDatasetByNodeId(ctx context.Context, nodeId string) (*pgdb.Dataset, error) {
+	return q.getDataset(ctx, fmt.Sprintf("node_id='%s'", nodeId))
 }
 
 // GetDatasetByName will query workspace datasets by name and return one if found.
 func (q *Queries) GetDatasetByName(ctx context.Context, name string) (*pgdb.Dataset, error) {
-	query := fmt.Sprintf("SELECT id, name, state, description, updated_at, created_at, node_id,"+
-		" permission_bit, type, role, status, automatically_process_packages, license, tags, contributors,"+
-		" banner_id, readme_id, status_id, publication_status_id, size, etag, data_use_agreement_id, changelog_id"+
-		" FROM datasets WHERE name='%s';", name)
-	row := q.db.QueryRowContext(ctx, query)
-	return scanDataset(row)
+	return q.getDataset(ctx, fmt.Sprintf("name='%s'", name))
 }
 
 // GetDatasets returns all rows in the Upload Record Table
@@ -381,6 +376,15 @@ func datasetRoleToPermission(r role.Role) pgdb.DbPermission {
 	default:
 		return pgdb.NoPermission
 	}
+}
+
+func (q *Queries) getDataset(ctx context.Context, predicate string) (*pgdb.Dataset, error) {
+	query := fmt.Sprintf("SELECT id, name, state, description, updated_at, created_at, node_id,"+
+		" permission_bit, type, role, status, automatically_process_packages, license, tags, contributors,"+
+		" banner_id, readme_id, status_id, publication_status_id, size, etag, data_use_agreement_id, changelog_id"+
+		" FROM datasets WHERE %s;", predicate)
+	row := q.db.QueryRowContext(ctx, query)
+	return scanDataset(row)
 }
 
 func scanDataset(row *sql.Row) (*pgdb.Dataset, error) {

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -110,12 +110,12 @@ func (q *Queries) CreateDataset(ctx context.Context, p CreateDatasetParams) (*pg
 	return dataset, nil
 }
 
-func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, origin string, url string) (*pgdb.DatasetRelease, error) {
+func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, label string, marker string) (*pgdb.DatasetRelease, error) {
 	query := "SELECT id, dataset_id, origin, url, label, marker, release_date, created_at, updated_at " +
-		"FROM dataset_release WHERE dataset_id = $1 AND origin = $2 AND url = $3"
+		"FROM dataset_release WHERE dataset_id = $1 AND label = $2 AND marker = $3"
 
 	var datasetRelease pgdb.DatasetRelease
-	row := q.db.QueryRowContext(ctx, query, datasetId, origin, url)
+	row := q.db.QueryRowContext(ctx, query, datasetId, label, marker)
 	err := row.Scan(
 		&datasetRelease.Id,
 		&datasetRelease.DatasetId,
@@ -130,7 +130,7 @@ func (q *Queries) GetDatasetRelease(ctx context.Context, datasetId int64, origin
 
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, &DatasetReleaseNotFoundError{fmt.Sprintf("dataset release not found for datasetId %d origin %s url %s", datasetId, origin, url)}
+			return nil, &DatasetReleaseNotFoundError{fmt.Sprintf("dataset release not found for datasetId %d label %s marker %s", datasetId, label, marker)}
 		} else {
 			return nil, fmt.Errorf(fmt.Sprintf("database error on query: %v", err))
 		}

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -85,13 +85,13 @@ func TestDatasets(t *testing.T) {
 		"Get Dataset by Name":              testGetDatasetByName,
 		"Create Dataset":                   testCreateDataset,
 		"Default Dataset type is research": testDefaultDatasetType,
+		"Create Dataset type 'release'":    testCreateDatasetTypeRelease,
 		"Add Owner to Dataset":             testAddOwnerToDataset,
 		"Add Viewer to Dataset":            testAddViewerToDataset,
 		"Add Editor to Dataset":            testAddEditorToDataset,
 		"Add Manager to Dataset":           testAddManagerToDataset,
 		"Unspecified License is Null":      testUnspecifiedLicenseIsNull,
 		"Empty String License Is Null":     testEmptyStringLicenseIsNull,
-		"Create Dataset Release":           testCreateDatasetRelease,
 		"Update updatedAt timestamp":       testUpdatedAtChange,
 	} {
 		t.Run(scenario, func(t *testing.T) {
@@ -317,33 +317,28 @@ func testDefaultDatasetType(t *testing.T, store *SQLStore, orgId int) {
 	assert.Equal(t, datasetType.Research.String(), ds.Type)
 }
 
-func testCreateDatasetRelease(t *testing.T, store *SQLStore, orgId int) {
+func testCreateDatasetTypeRelease(t *testing.T, store *SQLStore, orgId int) {
 	var err error
 	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
 	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default dataset status")
+		fmt.Errorf("testCreateDatasetTypeRelease(): failed to get default dataset status")
 	}
 	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
 	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
+		fmt.Errorf("testCreateDatasetTypeRelease(): failed to get default data use agreement")
 	}
 	createDatasetParams := CreateDatasetParams{
-		Name:                         "Test Dataset Release",
-		Description:                  "Test Dataset Release - description",
+		Name:                         "Test Dataset type is release",
+		Description:                  "Test Dataset type is release - description",
 		Status:                       defaultDatasetStatus,
 		AutomaticallyProcessPackages: false,
-		License:                      "Apache 2.0",
+		License:                      "Community Data License Agreement – Sharing",
 		Tags:                         nil,
 		DataUseAgreement:             defaultDataUseAgreement,
 		Type:                         datasetType.Release,
 	}
-	origin := "GitHub"
-	url := "https://github.com/Pennsieve/github-service"
-	dsr, err := store.CreateDatasetTypeRelease(context.TODO(), createDatasetParams, origin, url)
+	ds, err := store.CreateDataset(context.TODO(), createDatasetParams)
 	assert.NoError(t, err)
-	assert.Equal(t, createDatasetParams.Name, dsr.Dataset.Name)
-	assert.Equal(t, datasetType.Release.String(), dsr.Dataset.Type)
-	assert.Equal(t, origin, dsr.Release.Origin)
-	assert.Equal(t, url, dsr.Release.Url)
-	assert.Equal(t, dsr.Dataset.Id, dsr.Release.DatasetId)
+	assert.Equal(t, createDatasetParams.Name, ds.Name)
+	assert.Equal(t, datasetType.Release.String(), ds.Type)
 }

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -70,6 +70,7 @@ func TestDatasets(t *testing.T) {
 	db := testDB[orgId]
 	store := NewSQLStore(db)
 
+	addTestDataset(db, "Test Dataset - GetDatasetById")
 	addTestDataset(db, "Test Dataset - GetDatasetByName")
 	addTestDataset(db, "Test Dataset - AddOwnerToDataset")
 	addTestDataset(db, "Test Dataset - AddViewerToDataset")
@@ -80,6 +81,7 @@ func TestDatasets(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
+		"Get Dataset by Id":                testGetDatasetById,
 		"Get Dataset by Name":              testGetDatasetByName,
 		"Create Dataset":                   testCreateDataset,
 		"Default Dataset type is research": testDefaultDatasetType,
@@ -98,6 +100,15 @@ func TestDatasets(t *testing.T) {
 			fn(t, store, orgId)
 		})
 	}
+}
+
+func testGetDatasetById(t *testing.T, store *SQLStore, orgId int) {
+	name := "Test Dataset - GetDatasetById"
+	id := addTestDataset(store.db, name)
+	ds, err := store.GetDatasetById(context.TODO(), id)
+	assert.NoError(t, err)
+	assert.Equal(t, name, ds.Name)
+	assert.Equal(t, id, ds.Id)
 }
 
 func testGetDatasetByName(t *testing.T, store *SQLStore, orgId int) {


### PR DESCRIPTION
Added create, get, and update functions for the `dataset_release` table. 

At creation, these columns are required:
- `dataset_id`
- `origin`
- `url`
- `release_status`
- `publishing_status`

Values for `label`, `marker`, and `release_date` may be provided, but are optional. 

On update, these columns may be modified:
- `label` 
- `marker`
- `release_date`
- `release_status`
- `publishing_status`

The update operation requires the `id` value of the `dataset_release` row to be modified.

Added functions to get a dataset:
- by its `id` number
- by its `node_id` value
