### PR TITLE
Updates for Go authorizer Lambda

### DIFF
--- a/pkg/queries/pgdb/featureFlags.go
+++ b/pkg/queries/pgdb/featureFlags.go
@@ -2,33 +2,53 @@ package pgdb
 
 import (
 	"context"
+	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
 	log "github.com/sirupsen/logrus"
 )
 
+const featureFlagBaseQuery = "SELECT organization_id, feature, enabled,created_at, updated_at FROM pennsieve.feature_flags WHERE organization_id=$1"
+
+// queryFeatureFlags assumes that query is a select statement with columns and order as in featureFlagBaseQuery.
+func queryFeatureFlags(ctx context.Context, db DBTX, query string, params ...any) ([]pgdb.FeatureFlags, error) {
+	rows, err := db.QueryContext(ctx, query, params...)
+	if err != nil {
+		return nil, fmt.Errorf("error getting feature flags with query %s: %w", query, err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Warn("error closing feature flag rows after query:", query, "error:", err)
+		}
+	}()
+
+	var featureFlags []pgdb.FeatureFlags
+	for rows.Next() {
+		var currentRecord pgdb.FeatureFlags
+		if err := rows.Scan(
+			&currentRecord.OrganizationId,
+			&currentRecord.Feature,
+			&currentRecord.Enabled,
+			&currentRecord.CreatedAt,
+			&currentRecord.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("error scanning feature flag rows with query %s: %w", query, err)
+		}
+
+		featureFlags = append(featureFlags, currentRecord)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error during feature flag row iteration with query %s: %w", query, err)
+	}
+	return featureFlags, err
+
+}
+
 // GetFeatureFlags returns all rows in the FeatureFlags Table
 func (q *Queries) GetFeatureFlags(ctx context.Context, organizationId int64) ([]pgdb.FeatureFlags, error) {
-	queryStr := "SELECT organization_id, feature, enabled,created_at, updated_at FROM pennsieve.feature_flags WHERE organization_id=$1; "
+	return queryFeatureFlags(ctx, q.db, featureFlagBaseQuery, organizationId)
+}
 
-	rows, err := q.db.QueryContext(ctx, queryStr, organizationId)
-	var allFeatureFlags []pgdb.FeatureFlags
-	if err == nil {
-		for rows.Next() {
-			var currentRecord pgdb.FeatureFlags
-			err = rows.Scan(
-				&currentRecord.OrganizationId,
-				&currentRecord.Feature,
-				&currentRecord.Enabled,
-				&currentRecord.CreatedAt,
-				&currentRecord.UpdatedAt)
+func (q *Queries) GetEnabledFeatureFlags(ctx context.Context, organizationId int64) ([]pgdb.FeatureFlags, error) {
+	query := fmt.Sprintf("%s AND enabled = true", featureFlagBaseQuery)
+	return queryFeatureFlags(ctx, q.db, query, organizationId)
 
-			if err != nil {
-				log.Println("ERROR: ", err)
-			}
-
-			allFeatureFlags = append(allFeatureFlags, currentRecord)
-		}
-		return allFeatureFlags, err
-	}
-	return allFeatureFlags, err
 }

--- a/pkg/queries/pgdb/featureFlags_test.go
+++ b/pkg/queries/pgdb/featureFlags_test.go
@@ -54,6 +54,7 @@ func TestQueries_GetEnabledFeatureFlags(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore,
 	){
+		"no feature flags":           testNoFeatureFlagsGetEnabled,
 		"no enabled feature flags":   testNoEnabledFeatureFlags,
 		"some enabled feature flags": testSomeEnabledFeatureFlags,
 	} {
@@ -64,8 +65,15 @@ func TestQueries_GetEnabledFeatureFlags(t *testing.T) {
 	}
 }
 
-func testNoEnabledFeatureFlags(t *testing.T, store *SQLStore) {
+func testNoFeatureFlagsGetEnabled(t *testing.T, store *SQLStore) {
 	orgId := int64(2)
+	featureFlags, err := store.GetEnabledFeatureFlags(context.Background(), orgId)
+	require.NoError(t, err)
+	assert.Empty(t, featureFlags)
+}
+
+func testNoEnabledFeatureFlags(t *testing.T, store *SQLStore) {
+	orgId := int64(403)
 	featureFlags, err := store.GetEnabledFeatureFlags(context.Background(), orgId)
 	require.NoError(t, err)
 	assert.Empty(t, featureFlags)

--- a/pkg/queries/pgdb/featureFlags_test.go
+++ b/pkg/queries/pgdb/featureFlags_test.go
@@ -1,0 +1,87 @@
+package pgdb
+
+import (
+	"context"
+	"fmt"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"slices"
+	"testing"
+)
+
+func TestQueries_GetFeatureFlags(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore,
+	){
+		"no feature flags":   testNoFeatureFlags,
+		"some feature flags": testSomeFeatureFlags,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			store := NewSQLStore(testDB[0])
+			fn(t, store)
+		})
+	}
+}
+
+func testNoFeatureFlags(t *testing.T, store *SQLStore) {
+	orgId := int64(2)
+	featureFlags, err := store.GetFeatureFlags(context.Background(), orgId)
+	require.NoError(t, err)
+	assert.Empty(t, featureFlags)
+}
+
+func testSomeFeatureFlags(t *testing.T, store *SQLStore) {
+	orgId := int64(402)
+	featureFlags, err := store.GetFeatureFlags(context.Background(), orgId)
+	require.NoError(t, err)
+
+	assert.Len(t, featureFlags, 5)
+	disabledIndex := slices.IndexFunc(featureFlags, func(flag pgdb.FeatureFlags) bool {
+		return flag.Feature == "disabled feature" && flag.Enabled == false
+	})
+	assert.True(t, disabledIndex >= 0, "expected disabled feature not found in %s", featureFlags)
+	enabledFeatures := []string{"one", "two", "three", "four"}
+	for _, enabledFeature := range enabledFeatures {
+		index := slices.IndexFunc(featureFlags, func(flag pgdb.FeatureFlags) bool {
+			return flag.Enabled && flag.Feature == fmt.Sprintf("feature %s", enabledFeature)
+		})
+		assert.True(t, index >= 0, "expected enabled feature %s not found in %s", enabledFeature, featureFlags)
+	}
+}
+
+func TestQueries_GetEnabledFeatureFlags(t *testing.T) {
+	for scenario, fn := range map[string]func(
+		tt *testing.T, store *SQLStore,
+	){
+		"no enabled feature flags":   testNoEnabledFeatureFlags,
+		"some enabled feature flags": testSomeEnabledFeatureFlags,
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			store := NewSQLStore(testDB[0])
+			fn(t, store)
+		})
+	}
+}
+
+func testNoEnabledFeatureFlags(t *testing.T, store *SQLStore) {
+	orgId := int64(2)
+	featureFlags, err := store.GetEnabledFeatureFlags(context.Background(), orgId)
+	require.NoError(t, err)
+	assert.Empty(t, featureFlags)
+}
+
+func testSomeEnabledFeatureFlags(t *testing.T, store *SQLStore) {
+	orgId := int64(402)
+	featureFlags, err := store.GetEnabledFeatureFlags(context.Background(), orgId)
+	require.NoError(t, err)
+
+	assert.Len(t, featureFlags, 4)
+	enabledFeatures := []string{"one", "two", "three", "four"}
+	for _, enabledFeature := range enabledFeatures {
+		index := slices.IndexFunc(featureFlags, func(flag pgdb.FeatureFlags) bool {
+			return flag.Enabled && flag.Feature == fmt.Sprintf("feature %s", enabledFeature)
+		})
+		assert.True(t, index >= 0, "expected enabled feature %s not found in %s", enabledFeature, featureFlags)
+	}
+}

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -100,39 +100,17 @@ func (q *Queries) AddOrganizationUser(ctx context.Context, orgId int64, userId i
 	return orgUser, nil
 }
 
-// GetOrganizationClaim returns an organization claim for a specific user.
+// GetOrganizationClaim returns an organization claim for a specific user given a workspace id
 func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organizationId int64) (*organization.Claim, error) {
-
-	currentOrgUser, err := q.GetOrganizationUser(ctx, organizationId, userId)
-	if err != nil {
-		log.Error("Unable to check Org User: ", err)
-		return nil, err
-	}
-
-	org, err := q.GetOrganization(ctx, organizationId)
-	if err != nil {
-		log.Error("Unable to check Organization: ", err)
-		return nil, err
-	}
-
-	enabledFeatures, err := q.GetEnabledFeatureFlags(ctx, organizationId)
-	if err != nil {
-		log.Error("Unable to check Feature Flags: ", err)
-		return nil, err
-	}
-
-	orgRole := organization.Claim{
-		Role:            currentOrgUser.DbPermission,
-		IntId:           organizationId,
-		NodeId:          org.NodeId,
-		EnabledFeatures: enabledFeatures,
-	}
-
-	return &orgRole, nil
-
+	return queryOrganizationClaim(ctx, q.db, &orgClaimByOrgId, userId, organizationId)
 }
 
-// nullableFeatureFlag is a temp struct used to hold results from the query used by GetOrganizationClaimByNodeId which
+// GetOrganizationClaimByNodeId returns an organization claim for a specific user given a workspace node id
+func (q *Queries) GetOrganizationClaimByNodeId(ctx context.Context, userId int64, organizationNodeId string) (*organization.Claim, error) {
+	return queryOrganizationClaim(ctx, q.db, &orgClaimByOrgNodeId, userId, organizationNodeId)
+}
+
+// nullableFeatureFlag is a temp struct used to hold results from the query used by queryOrganizationClaim which
 // will return rows with null values for featureFlag columns if the org has no flags set
 type nullableFeatureFlag struct {
 	feature   sql.NullString
@@ -141,7 +119,7 @@ type nullableFeatureFlag struct {
 	updatedAt sql.NullTime
 }
 
-func (n nullableFeatureFlag) Valid() bool {
+func (n nullableFeatureFlag) valid() bool {
 	return n.feature.Valid && n.enabled.Valid && n.createdAt.Valid && n.updatedAt.Valid
 }
 
@@ -155,57 +133,90 @@ func (n nullableFeatureFlag) toFeatureFlag(organizationId int64) pgdb.FeatureFla
 	}
 }
 
-func (q *Queries) GetOrganizationClaimByNodeId(ctx context.Context, userId int64, organizationNodeId string) (*organization.Claim, error) {
-	query := `SELECT o.id, ou.permission_bit, f.feature, f.enabled, f.created_at, f.updated_at 
-			  FROM pennsieve.users u JOIN pennsieve.organization_user ou ON u.id = ou.user_id
-         			                 JOIN pennsieve.organizations o ON ou.organization_id = o.id
-         			            LEFT JOIN pennsieve.feature_flags f ON o.id = f.organization_id and f.enabled = true
-			  WHERE u.id = $1 AND o.node_id = $2`
+type orgClaimQuery struct {
+	name            string
+	query           string
+	paramsMsgFormat string
+}
 
-	rows, err := q.db.QueryContext(ctx, query, userId, organizationNodeId)
+func (q *orgClaimQuery) String() string {
+	return q.name
+}
+
+func (q *orgClaimQuery) paramsMsg(userId int64, orgIdentifier any) string {
+	return fmt.Sprintf(q.paramsMsgFormat, userId, orgIdentifier)
+}
+
+const orgClaimQueryFormat = `SELECT o.id, o.node_id, ou.permission_bit, f.feature, f.enabled, f.created_at, f.updated_at 
+			  		         FROM pennsieve.users u JOIN pennsieve.organization_user ou ON u.id = ou.user_id
+         			             			        JOIN pennsieve.organizations o ON ou.organization_id = o.id
+         			                           LEFT JOIN pennsieve.feature_flags f ON o.id = f.organization_id and f.enabled = true
+			                 WHERE u.id = $1 AND %s = $2`
+
+// orgClaimByOrgNodeId is the query to get an org claim given a user id and workspace node id
+var orgClaimByOrgNodeId = orgClaimQuery{
+	name:            "GetOrganizationClaimByNodeId",
+	query:           fmt.Sprintf(orgClaimQueryFormat, "o.node_id"),
+	paramsMsgFormat: "user id: %d, workspace node id: %s",
+}
+
+// orgClaimByOrgId is the query to get an org claim given a user id and workspace (int) id
+var orgClaimByOrgId = orgClaimQuery{
+	name:            "GetOrganizationClaim",
+	query:           fmt.Sprintf(orgClaimQueryFormat, "o.id"),
+	paramsMsgFormat: "user id: %d, workspace id: %d",
+}
+
+// queryOrganizationClaim constructs an org claim from the given query and params. It assumes that the given query
+// is like orgClaimQueryFormat: it has those columns in that order, and has two positional params. $1 is the user id
+// and $2 is the org identifier, either the int or node id of the workspace.
+func queryOrganizationClaim(ctx context.Context, db DBTX, orgClaimQuery *orgClaimQuery, userId int64, orgIdentifier any) (*organization.Claim, error) {
+	rows, err := db.QueryContext(ctx, orgClaimQuery.query, userId, orgIdentifier)
 	if err != nil {
-		return nil, fmt.Errorf("error getting organization claim by node id: %w", err)
+		return nil, fmt.Errorf("error getting organization claim with query %s: %w", orgClaimQuery, err)
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
-			log.Warn("error closing rows for get organization claim by node id", err)
+			log.Warn("error closing rows for get organization claim with query", orgClaimQuery, "error:", err)
 		}
 	}()
 
-	// orgId and orgPerms may get multiple scans below (if the org has >1 feature flag) but should always be the same value. Not
+	// orgId, orgNodeId, and orgPerms may get multiple scans below (if the org has >1 feature flag) but should always be the same value. Not
 	// sure how else to handle this except with the redundant scans.
 	var orgId int64
+	var orgNodeId string
 	var orgPerms pgdb.DbPermission
 	var flags []pgdb.FeatureFlags
 	for rows.Next() {
 		var nullableFlag nullableFeatureFlag
 		if err := rows.Scan(
 			&orgId,
+			&orgNodeId,
 			&orgPerms,
 			&nullableFlag.feature,
 			&nullableFlag.enabled,
 			&nullableFlag.createdAt,
 			&nullableFlag.updatedAt); err != nil {
-			return nil, fmt.Errorf("error reading row for get organization claim by node id: %w", err)
+			return nil, fmt.Errorf("error reading row for get organization claim with query %s: %w", orgClaimQuery, err)
 		}
 		// an org may have no feature flags. don't add a bunch of zero-ed structs to claim
-		if nullableFlag.Valid() {
+		if nullableFlag.valid() {
 			featureFlag := nullableFlag.toFeatureFlag(orgId)
 			flags = append(flags, featureFlag)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row error on get organization claim by node id: %w", err)
+		return nil, fmt.Errorf("row error on get organization claim with query %s: %w", orgClaimQuery, err)
 	}
 	// zero orgId means no rows returned.
 	if orgId == 0 {
-		return nil, OrganizationUserNotFoundError{fmt.Sprintf("user id: %d, organization node id: %s", userId, organizationNodeId)}
+		return nil, OrganizationUserNotFoundError{orgClaimQuery.paramsMsg(userId, orgIdentifier)}
 	}
 
 	return &organization.Claim{
 		Role:            orgPerms,
 		IntId:           orgId,
-		NodeId:          organizationNodeId,
+		NodeId:          orgNodeId,
 		EnabledFeatures: flags,
 	}, nil
 }

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -115,7 +115,7 @@ func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organi
 		return nil, err
 	}
 
-	allFeatures, err := q.GetFeatureFlags(ctx, organizationId)
+	enabledFeatures, err := q.GetEnabledFeatureFlags(ctx, organizationId)
 	if err != nil {
 		log.Error("Unable to check Feature Flags: ", err)
 		return nil, err
@@ -125,7 +125,7 @@ func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organi
 		Role:            currentOrgUser.DbPermission,
 		IntId:           organizationId,
 		NodeId:          org.NodeId,
-		EnabledFeatures: allFeatures,
+		EnabledFeatures: enabledFeatures,
 	}
 
 	return &orgRole, nil
@@ -159,7 +159,7 @@ func (q *Queries) GetOrganizationClaimByNodeId(ctx context.Context, userId int64
 	query := `SELECT o.id, ou.permission_bit, f.feature, f.enabled, f.created_at, f.updated_at 
 			  FROM pennsieve.users u JOIN pennsieve.organization_user ou ON u.id = ou.user_id
          			                 JOIN pennsieve.organizations o ON ou.organization_id = o.id
-         			            LEFT JOIN pennsieve.feature_flags f ON o.id = f.organization_id
+         			            LEFT JOIN pennsieve.feature_flags f ON o.id = f.organization_id and f.enabled = true
 			  WHERE u.id = $1 AND o.node_id = $2`
 
 	rows, err := q.db.QueryContext(ctx, query, userId, organizationNodeId)

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -132,7 +132,7 @@ func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organi
 
 }
 
-// nullableFeatureFlag is a temp struct used to hold results from GetOrganizationClaimByNodeId which
+// nullableFeatureFlag is a temp struct used to hold results from the query used by GetOrganizationClaimByNodeId which
 // will return rows with null values for featureFlag columns if the org has no flags set
 type nullableFeatureFlag struct {
 	feature   sql.NullString

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -147,6 +147,10 @@ func (q *orgClaimQuery) paramsMsg(userId int64, orgIdentifier any) string {
 	return fmt.Sprintf(q.paramsMsgFormat, userId, orgIdentifier)
 }
 
+// orgClaimQueryFormat is the base query used by both *Queries.GetOrganizationClaim and *Queries.GetOrganizationClaimByNodeId
+// to construct org claims.
+// The only difference is that *Queries.GetOrganizationClaim uses the org's int id as the organization identifier
+// (query parameter $2) and *Queries.GetOrganizationClaimByNodeId uses the org's node id instead.
 const orgClaimQueryFormat = `SELECT o.id, o.node_id, ou.permission_bit, f.feature, f.enabled, f.created_at, f.updated_at 
 			  		         FROM pennsieve.users u JOIN pennsieve.organization_user ou ON u.id = ou.user_id
          			             			        JOIN pennsieve.organizations o ON ou.organization_id = o.id

--- a/pkg/queries/pgdb/organizationUser.go
+++ b/pkg/queries/pgdb/organizationUser.go
@@ -131,3 +131,81 @@ func (q *Queries) GetOrganizationClaim(ctx context.Context, userId int64, organi
 	return &orgRole, nil
 
 }
+
+// nullableFeatureFlag is a temp struct used to hold results from GetOrganizationClaimByNodeId which
+// will return rows with null values for featureFlag columns if the org has no flags set
+type nullableFeatureFlag struct {
+	feature   sql.NullString
+	enabled   sql.NullBool
+	createdAt sql.NullTime
+	updatedAt sql.NullTime
+}
+
+func (n nullableFeatureFlag) Valid() bool {
+	return n.feature.Valid && n.enabled.Valid && n.createdAt.Valid && n.updatedAt.Valid
+}
+
+func (n nullableFeatureFlag) toFeatureFlag(organizationId int64) pgdb.FeatureFlags {
+	return pgdb.FeatureFlags{
+		OrganizationId: organizationId,
+		Feature:        n.feature.String,
+		Enabled:        n.enabled.Bool,
+		CreatedAt:      n.createdAt.Time,
+		UpdatedAt:      n.updatedAt.Time,
+	}
+}
+
+func (q *Queries) GetOrganizationClaimByNodeId(ctx context.Context, userId int64, organizationNodeId string) (*organization.Claim, error) {
+	query := `SELECT o.id, ou.permission_bit, f.feature, f.enabled, f.created_at, f.updated_at 
+			  FROM pennsieve.users u JOIN pennsieve.organization_user ou ON u.id = ou.user_id
+         			                 JOIN pennsieve.organizations o ON ou.organization_id = o.id
+         			            LEFT JOIN pennsieve.feature_flags f ON o.id = f.organization_id
+			  WHERE u.id = $1 AND o.node_id = $2`
+
+	rows, err := q.db.QueryContext(ctx, query, userId, organizationNodeId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting organization claim by node id: %w", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Warn("error closing rows for get organization claim by node id", err)
+		}
+	}()
+
+	// orgId and orgPerms may get multiple scans below (if the org has >1 feature flag) but should always be the same value. Not
+	// sure how else to handle this except with the redundant scans.
+	var orgId int64
+	var orgPerms pgdb.DbPermission
+	var flags []pgdb.FeatureFlags
+	for rows.Next() {
+		var nullableFlag nullableFeatureFlag
+		if err := rows.Scan(
+			&orgId,
+			&orgPerms,
+			&nullableFlag.feature,
+			&nullableFlag.enabled,
+			&nullableFlag.createdAt,
+			&nullableFlag.updatedAt); err != nil {
+			return nil, fmt.Errorf("error reading row for get organization claim by node id: %w", err)
+		}
+		// an org may have no feature flags. don't add a bunch of zero-ed structs to claim
+		if nullableFlag.Valid() {
+			featureFlag := nullableFlag.toFeatureFlag(orgId)
+			flags = append(flags, featureFlag)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row error on get organization claim by node id: %w", err)
+	}
+	// zero orgId means no rows returned.
+	if orgId == 0 {
+		return nil, OrganizationUserNotFoundError{fmt.Sprintf("user id: %d, organization node id: %s", userId, organizationNodeId)}
+	}
+
+	return &organization.Claim{
+		Role:            orgPerms,
+		IntId:           orgId,
+		NodeId:          organizationNodeId,
+		EnabledFeatures: flags,
+	}, nil
+}

--- a/pkg/queries/pgdb/organizationUser_test.go
+++ b/pkg/queries/pgdb/organizationUser_test.go
@@ -151,11 +151,7 @@ func testGetOrganizationClaimManyFeatureFlags(t *testing.T, store *SQLStore, org
 	assert.Equal(t, organizationId, orgClaim.IntId)
 	assert.Equal(t, org402NodeId, orgClaim.NodeId)
 	assert.Equal(t, pgdb.Read, orgClaim.Role)
-	assert.Len(t, orgClaim.EnabledFeatures, 5)
-	disabledIndex := slices.IndexFunc(orgClaim.EnabledFeatures, func(flag pgdb.FeatureFlags) bool {
-		return flag.Feature == "disabled feature" && flag.Enabled == false
-	})
-	assert.True(t, disabledIndex >= 0, "expected disabled feature not found in %s", orgClaim.EnabledFeatures)
+	assert.Len(t, orgClaim.EnabledFeatures, 4)
 	enabledFeatures := []string{"one", "two", "three", "four"}
 	for _, enabledFeature := range enabledFeatures {
 		index := slices.IndexFunc(orgClaim.EnabledFeatures, func(flag pgdb.FeatureFlags) bool {
@@ -172,11 +168,7 @@ func testGetOrganizationClaimManyFeatureFlags(t *testing.T, store *SQLStore, org
 		assert.Equal(t, organizationId, orgClaim.IntId)
 		assert.Equal(t, org402NodeId, orgClaim.NodeId)
 		assert.Equal(t, pgdb.Read, orgClaim.Role)
-		assert.Len(t, orgClaim.EnabledFeatures, 5)
-		disabledIndex := slices.IndexFunc(orgClaim.EnabledFeatures, func(flag pgdb.FeatureFlags) bool {
-			return flag.Feature == "disabled feature" && flag.Enabled == false
-		})
-		assert.True(t, disabledIndex >= 0, "expected disabled feature not found in %s", orgClaim.EnabledFeatures)
+		assert.Len(t, orgClaim.EnabledFeatures, 4)
 		enabledFeatures := []string{"one", "two", "three", "four"}
 		for _, enabledFeature := range enabledFeatures {
 			index := slices.IndexFunc(orgClaim.EnabledFeatures, func(flag pgdb.FeatureFlags) bool {

--- a/pkg/queries/pgdb/organizationUser_test.go
+++ b/pkg/queries/pgdb/organizationUser_test.go
@@ -2,8 +2,10 @@ package pgdb
 
 import (
 	"context"
+	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
 	"github.com/stretchr/testify/assert"
+	"slices"
 	"testing"
 )
 
@@ -11,11 +13,14 @@ func TestOrganizationUser(t *testing.T) {
 	for scenario, fn := range map[string]func(
 		tt *testing.T, store *SQLStore, orgId int,
 	){
-		"Get Organization User":           testGetOrganizationUser,
-		"Add Organization User":           testAddOrganizationUser,
-		"Add Existing OrgUser Membership": testAddExistingOrgUserMembership,
-		"Add Guest to Organization":       testAddGuestToOrganization,
-		"Get Organization Claim":          testGetOrganizationClaim,
+		"Get Organization User":                                  testGetOrganizationUser,
+		"Add Organization User":                                  testAddOrganizationUser,
+		"Add Existing OrgUser Membership":                        testAddExistingOrgUserMembership,
+		"Add Guest to Organization":                              testAddGuestToOrganization,
+		"Get Organization Claim":                                 testGetOrganizationClaim,
+		"Get Organization Claim error when no org user":          testGetOrganizationClaimNoOrgUser,
+		"Get Organization Claim when org has no feature flags":   testGetOrganizationClaimNoFeatureFlags,
+		"Get Organization Claim when org has many feature flags": testGetOrganizationClaimManyFeatureFlags,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 1
@@ -86,4 +91,68 @@ func testGetOrganizationClaim(t *testing.T, store *SQLStore, orgId int) {
 	assert.NoError(t, err)
 	assert.Equal(t, organizationId, orgClaim.IntId)
 	assert.Equal(t, org.NodeId, orgClaim.NodeId)
+	assert.Equal(t, pgdb.Delete, orgClaim.Role)
+	// org 1 is the sandbox org created by migrations in the seed DB.
+	// It has one feature flag
+	assert.Len(t, orgClaim.EnabledFeatures, 1)
+	assert.Equal(t, "sandbox_org_feature", orgClaim.EnabledFeatures[0].Feature)
+	assert.Equal(t, organizationId, orgClaim.EnabledFeatures[0].OrganizationId)
+	assert.True(t, orgClaim.EnabledFeatures[0].Enabled)
+}
+
+func testGetOrganizationClaimNoOrgUser(t *testing.T, store *SQLStore, _ int) {
+	// store_test.go and tests in this file do not add user 1002 to org 1
+	userId := int64(1002)
+	organizationId := int64(1)
+
+	_, err := store.GetOrganizationClaim(context.TODO(), userId, organizationId)
+	assert.ErrorContains(t, err, "organization user was not found")
+}
+
+func testGetOrganizationClaimNoFeatureFlags(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(1002)
+	organizationId := int64(2)
+
+	// get the organization so that we can check NodeId
+	org, err := store.GetOrganization(context.TODO(), organizationId)
+	assert.NoError(t, err)
+	assert.Equal(t, organizationId, org.Id)
+
+	// get the organization claim
+	orgClaim, err := store.GetOrganizationClaim(context.TODO(), userId, organizationId)
+	assert.NoError(t, err)
+	assert.Equal(t, organizationId, orgClaim.IntId)
+	assert.Equal(t, org.NodeId, orgClaim.NodeId)
+	assert.Equal(t, pgdb.Delete, orgClaim.Role)
+	assert.Empty(t, orgClaim.EnabledFeatures)
+}
+
+func testGetOrganizationClaimManyFeatureFlags(t *testing.T, store *SQLStore, orgId int) {
+	userId := int64(3402)
+	organizationId := int64(402)
+
+	// get the organization so that we can check NodeId
+	org, err := store.GetOrganization(context.TODO(), organizationId)
+	assert.NoError(t, err)
+	assert.Equal(t, organizationId, org.Id)
+
+	// get the organization claim
+	orgClaim, err := store.GetOrganizationClaim(context.TODO(), userId, organizationId)
+	assert.NoError(t, err)
+	assert.Equal(t, organizationId, orgClaim.IntId)
+	assert.Equal(t, org.NodeId, orgClaim.NodeId)
+	assert.Equal(t, pgdb.Read, orgClaim.Role)
+	assert.Len(t, orgClaim.EnabledFeatures, 5)
+	disabledIndex := slices.IndexFunc(orgClaim.EnabledFeatures, func(flag pgdb.FeatureFlags) bool {
+		return flag.Feature == "disabled feature" && flag.Enabled == false
+	})
+	assert.True(t, disabledIndex >= 0, "expected disabled feature not found in %s", orgClaim.EnabledFeatures)
+	enabledFeatures := []string{"one", "two", "three", "four"}
+	for _, enabledFeature := range enabledFeatures {
+		index := slices.IndexFunc(orgClaim.EnabledFeatures, func(flag pgdb.FeatureFlags) bool {
+			return flag.Enabled && flag.Feature == fmt.Sprintf("feature %s", enabledFeature)
+		})
+		assert.True(t, index >= 0, "expected enabled feature %s not found in %s", enabledFeature, orgClaim.EnabledFeatures)
+
+	}
 }

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -19,6 +19,14 @@ var publishingTeamId int64
 var publishingTeamName string
 var publishingTeamNodeId string
 
+// From seed DB
+const org1NodeId = "N:organization:88c078d6-1827-4e14-867b-801448fe0622"
+const org2NodeId = "N:organization:320813c5-3ea3-4c3b-aca5-9c6221e8d5f8"
+const org3NodeId = "N:organization:4fb6fec6-9b2e-4885-91ff-7b3cf6579cd0"
+const org4NodeId = "N:organization:8f60b0fd-55b7-4efa-b1b1-8204111117d3"
+
+const org402NodeId = "N:organization:b137251c-ff5c-45aa-8c7e-9a168be5d94e"
+
 func logFatalError(message string, err error) {
 	log.Fatal(fmt.Sprintf("%s (error: %+v)", message, err))
 }
@@ -90,7 +98,7 @@ func addOrganization(db *sql.DB) {
 			Id:     402,
 			Name:   "Lots of Features",
 			Slug:   "featureful",
-			NodeId: "N:organization:b137251c-ff5c-45aa-8c7e-9a168be5d94e",
+			NodeId: org402NodeId,
 		},
 			encryptionKeyId: "NO_ENCRYPTION_KEY"},
 	}

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -3,12 +3,11 @@ package pgdb
 import (
 	"database/sql"
 	"fmt"
-	"os"
-	"testing"
-
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/nodeId"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
 	log "github.com/sirupsen/logrus"
+	"os"
+	"testing"
 )
 
 var testDB map[int]*sql.DB
@@ -34,10 +33,11 @@ func TestMain(m *testing.M) {
 		log.Fatal("cannot connect to db:", err)
 	}
 	testDB[0] = db0
+	addOrganization(db0)
+	addFeatureFlags(db0)
 	addUsers(db0)
 	addIntegrationUsers(db0)
 	addUsersToOrganizations(db0)
-	addOrganization(db0)
 	addResearchTeam(db0)
 	addPublishingTeam(db0)
 	addTeamToOrganization(db0, 1, researchTeamId, "")
@@ -75,10 +75,48 @@ func TestMain(m *testing.M) {
 }
 
 func addOrganization(db *sql.DB) {
+	orgs := []struct {
+		pgdb.Organization
+		encryptionKeyId string
+	}{
+		{Organization: pgdb.Organization{
+			Id:     42,
+			Name:   "Ultimate",
+			Slug:   "ultimate",
+			NodeId: "N:organization:2b809c6f-9941-47a2-9593-9540fbe77ff1",
+		},
+			encryptionKeyId: "NO_ENCRYPTION_KEY"},
+		{Organization: pgdb.Organization{
+			Id:     402,
+			Name:   "Lots of Features",
+			Slug:   "featureful",
+			NodeId: "N:organization:b137251c-ff5c-45aa-8c7e-9a168be5d94e",
+		},
+			encryptionKeyId: "NO_ENCRYPTION_KEY"},
+	}
 	statement := "INSERT INTO pennsieve.organizations (id, node_id, name, slug, encryption_key_id) VALUES ($1, $2, $3, $4, $5)"
-	_, err := db.Exec(statement, 42, "N:organization:2b809c6f-9941-47a2-9593-9540fbe77ff1", "Ultimate", "ultimate", "NO_ENCRYPTION_KEY")
-	if err != nil {
-		log.Fatal(fmt.Sprintf("unable to add organization"))
+	for _, org := range orgs {
+		_, err := db.Exec(statement, org.Id, org.NodeId, org.Name, org.Slug, org.encryptionKeyId)
+		if err != nil {
+			log.Fatal(fmt.Sprintf("unable to add organization with id: %d error: %s", org.Id, err))
+		}
+	}
+}
+
+func addFeatureFlags(db *sql.DB) {
+	features := []pgdb.FeatureFlags{
+		{OrganizationId: 402, Feature: "feature one", Enabled: true},
+		{OrganizationId: 402, Feature: "feature two", Enabled: true},
+		{OrganizationId: 402, Feature: "feature three", Enabled: true},
+		{OrganizationId: 402, Feature: "feature four", Enabled: true},
+		{OrganizationId: 402, Feature: "disabled feature", Enabled: false},
+	}
+	statement := "INSERT INTO pennsieve.feature_flags (organization_id, feature, enabled) VALUES ($1, $2, $3)"
+	for _, feature := range features {
+		_, err := db.Exec(statement, feature.OrganizationId, feature.Feature, feature.Enabled)
+		if err != nil {
+			log.Fatal(fmt.Sprintf("unable to add feature: %s to organization with id: %d error: %s", feature.Feature, feature.OrganizationId, err))
+		}
 	}
 }
 
@@ -108,6 +146,7 @@ func addUsers(db *sql.DB) {
 		{userId: 1002, nodeId: "N:user:2", emailAddress: "user2@pennsieve.org", firstName: "two", lastName: "user", preferredOrgId: 2, cognitoId: "22222222-2222-2222-2222-222222222222", isSuperAdmin: "f"},
 		{userId: 1003, nodeId: "N:user:3", emailAddress: "user3@pennsieve.org", firstName: "three", lastName: "user", preferredOrgId: 3, cognitoId: "33333333-3333-3333-3333-333333333333", isSuperAdmin: "f"},
 		{userId: 1004, nodeId: "N:user:4", emailAddress: "user4@pennsieve.org", firstName: "four", lastName: "user", preferredOrgId: 3, cognitoId: "44444444-4444-4444-4444-444444444444", isSuperAdmin: "f"},
+		{userId: 3402, nodeId: "N:user:3402", emailAddress: "user3402@pennsieve.org", firstName: "threefour", lastName: "ohtwo", preferredOrgId: 402, cognitoId: "34023402-3402-3402-3402-340234023402", isSuperAdmin: "f"},
 	}
 
 	statement := "INSERT INTO pennsieve.users (id, node_id, email, first_name, last_name, preferred_org_id, cognito_id, is_super_admin)" +
@@ -170,6 +209,7 @@ func addUsersToOrganizations(db *sql.DB) {
 		{organizationId: 3, userId: 1003, permissionBit: pgdb.Delete},
 		{organizationId: 3, userId: 1004, permissionBit: pgdb.Delete},
 		{organizationId: 1, userId: 2001, permissionBit: pgdb.Delete},
+		{organizationId: 402, userId: 3402, permissionBit: pgdb.Read},
 	}
 
 	statement := "INSERT INTO pennsieve.organization_user (organization_id, user_id, permission_bit) VALUES ($1, $2, $3)"
@@ -177,8 +217,8 @@ func addUsersToOrganizations(db *sql.DB) {
 	for _, membership := range memberships {
 		_, err := db.Exec(statement, membership.organizationId, membership.userId, membership.permissionBit)
 		if err != nil {
-			log.Fatal(fmt.Sprintf("unable to add organization membership org: %d user : %d perm: %d",
-				membership.organizationId, membership.userId, membership.permissionBit))
+			log.Fatal(fmt.Sprintf("unable to add organization membership org: %d user : %d perm: %d error: %s",
+				membership.organizationId, membership.userId, membership.permissionBit, err))
 		}
 	}
 }

--- a/pkg/queries/pgdb/store_test.go
+++ b/pkg/queries/pgdb/store_test.go
@@ -26,6 +26,7 @@ const org3NodeId = "N:organization:4fb6fec6-9b2e-4885-91ff-7b3cf6579cd0"
 const org4NodeId = "N:organization:8f60b0fd-55b7-4efa-b1b1-8204111117d3"
 
 const org402NodeId = "N:organization:b137251c-ff5c-45aa-8c7e-9a168be5d94e"
+const org403NodeId = "N:organization:025e9cab-427e-48f7-a423-113dd550cc2d"
 
 func logFatalError(message string, err error) {
 	log.Fatal(fmt.Sprintf("%s (error: %+v)", message, err))
@@ -101,6 +102,13 @@ func addOrganization(db *sql.DB) {
 			NodeId: org402NodeId,
 		},
 			encryptionKeyId: "NO_ENCRYPTION_KEY"},
+		{Organization: pgdb.Organization{
+			Id:     403,
+			Name:   "Lots of disabled Features",
+			Slug:   "disabled featureful",
+			NodeId: org403NodeId,
+		},
+			encryptionKeyId: "NO_ENCRYPTION_KEY"},
 	}
 	statement := "INSERT INTO pennsieve.organizations (id, node_id, name, slug, encryption_key_id) VALUES ($1, $2, $3, $4, $5)"
 	for _, org := range orgs {
@@ -118,6 +126,11 @@ func addFeatureFlags(db *sql.DB) {
 		{OrganizationId: 402, Feature: "feature three", Enabled: true},
 		{OrganizationId: 402, Feature: "feature four", Enabled: true},
 		{OrganizationId: 402, Feature: "disabled feature", Enabled: false},
+
+		{OrganizationId: 403, Feature: "disabled feature one", Enabled: false},
+		{OrganizationId: 403, Feature: "disabled feature two", Enabled: false},
+		{OrganizationId: 403, Feature: "disabled feature three", Enabled: false},
+		{OrganizationId: 403, Feature: "disabled feature four", Enabled: false},
 	}
 	statement := "INSERT INTO pennsieve.feature_flags (organization_id, feature, enabled) VALUES ($1, $2, $3)"
 	for _, feature := range features {
@@ -155,6 +168,7 @@ func addUsers(db *sql.DB) {
 		{userId: 1003, nodeId: "N:user:3", emailAddress: "user3@pennsieve.org", firstName: "three", lastName: "user", preferredOrgId: 3, cognitoId: "33333333-3333-3333-3333-333333333333", isSuperAdmin: "f"},
 		{userId: 1004, nodeId: "N:user:4", emailAddress: "user4@pennsieve.org", firstName: "four", lastName: "user", preferredOrgId: 3, cognitoId: "44444444-4444-4444-4444-444444444444", isSuperAdmin: "f"},
 		{userId: 3402, nodeId: "N:user:3402", emailAddress: "user3402@pennsieve.org", firstName: "threefour", lastName: "ohtwo", preferredOrgId: 402, cognitoId: "34023402-3402-3402-3402-340234023402", isSuperAdmin: "f"},
+		{userId: 3403, nodeId: "N:user:3403", emailAddress: "user3403@pennsieve.org", firstName: "threefour", lastName: "ohthree", preferredOrgId: 403, cognitoId: "34033403-3403-3403-3403-340334033403", isSuperAdmin: "f"},
 	}
 
 	statement := "INSERT INTO pennsieve.users (id, node_id, email, first_name, last_name, preferred_org_id, cognito_id, is_super_admin)" +
@@ -218,6 +232,7 @@ func addUsersToOrganizations(db *sql.DB) {
 		{organizationId: 3, userId: 1004, permissionBit: pgdb.Delete},
 		{organizationId: 1, userId: 2001, permissionBit: pgdb.Delete},
 		{organizationId: 402, userId: 3402, permissionBit: pgdb.Read},
+		{organizationId: 403, userId: 3403, permissionBit: pgdb.Read},
 	}
 
 	statement := "INSERT INTO pennsieve.organization_user (organization_id, user_id, permission_bit) VALUES ($1, $2, $3)"

--- a/pkg/queries/pgdb/tokens.go
+++ b/pkg/queries/pgdb/tokens.go
@@ -7,8 +7,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//GetTokenByCognitoId returns a user from Postgress based on his/her cognito-id
-//This function also returns the preferred org and whether the user is a super-admin.
+// GetTokenByCognitoId returns a user from Postgress based on his/her cognito-id
+// This function also returns the preferred org and whether the user is a super-admin.
 func (q *Queries) GetTokenByCognitoId(ctx context.Context, id string) (*pgdb.Token, error) {
 
 	queryStr := "SELECT id, name, token, organization_id, user_id, cognito_id, last_used, created_at, updated_at " +
@@ -41,13 +41,14 @@ func (q *Queries) GetTokenByCognitoId(ctx context.Context, id string) (*pgdb.Tok
 // GetUserByCognitoId returns a Pennsieve User based on the cognito id in the token pool.
 func (q *Queries) GetUserByCognitoId(ctx context.Context, id string) (*pgdb.User, error) {
 
-	queryStr := "SELECT pennsieve.users.id, email, first_name, last_name, is_super_admin, pennsieve.tokens.organization_id as preferred_org_id " +
+	queryStr := "SELECT pennsieve.users.id, pennsieve.users.node_id, email, first_name, last_name, is_super_admin, pennsieve.tokens.organization_id as preferred_org_id " +
 		"FROM pennsieve.users JOIN pennsieve.tokens ON pennsieve.tokens.user_id = pennsieve.users.id WHERE pennsieve.tokens.token=$1;"
 
 	var user pgdb.User
 	row := q.db.QueryRowContext(ctx, queryStr, id)
 	err := row.Scan(
 		&user.Id,
+		&user.NodeId,
 		&user.Email,
 		&user.FirstName,
 		&user.LastName,

--- a/pkg/queries/pgdb/tokens_test.go
+++ b/pkg/queries/pgdb/tokens_test.go
@@ -22,10 +22,12 @@ func TestTokens(t *testing.T) {
 
 func testGetTokenUserByCognitoId(t *testing.T, store *SQLStore, orgId int) {
 	userId := int64(2001)
+	userNodeId := "N:user:2001"
 	organizationId := int64(1)
 	cognitoId := "00000000-1111-0000-2222-000000002001"
 	user, err := store.GetUserByCognitoId(context.TODO(), cognitoId)
 	assert.NoError(t, err)
-	assert.Equal(t, user.Id, userId)
-	assert.Equal(t, user.PreferredOrg, organizationId)
+	assert.Equal(t, userId, user.Id)
+	assert.Equal(t, userNodeId, user.NodeId)
+	assert.Equal(t, organizationId, user.PreferredOrg)
 }


### PR DESCRIPTION
Adds a new `*Queries` method, `GetOrganizationClaimByNodeId` to allow the new Go workspace authorizer to get an org claim in one DB call without having to know the org int id first. For ticket https://app.clickup.com/t/868ayvqvm

Updates existing `*Queries` method `GetOrganizationClaim` to only include enabled feature flags in the returned claim. The new `GetOrganizationClaimByNodeId` behaves the same way. This brings the Go org claims methods into agreement with the existing Scala org claim code and the name of the field in the returned claim (`EnabledFeatures`).

Updates existing `*Queries` method `GetTokenByCognitoId` to include the user's node id in response.

Adds tests for these changes.
