### PR TITLE
Claims struct to hold pointers to structs

### DIFF
--- a/pkg/authorizer/claims.go
+++ b/pkg/authorizer/claims.go
@@ -26,7 +26,7 @@ type Claims struct {
 	OrgClaim     *organization.Claim
 	DatasetClaim *dataset.Claim
 	UserClaim    *user.Claim
-	TeamClaims   []*teamUser.Claim
+	TeamClaims   []teamUser.Claim
 }
 
 func (c *Claims) String() string {
@@ -75,13 +75,13 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 		}
 	}
 
-	var teamClaims []*teamUser.Claim
+	var teamClaims []teamUser.Claim
 	if val, ok := claims[LabelTeamClaims]; ok {
 		if val != nil {
 			tcs := val.([]interface{})
 			for _, item := range tcs {
 				tc := item.(map[string]interface{})
-				teamClaim := &teamUser.Claim{
+				teamClaim := teamUser.Claim{
 					IntId:      int64(tc["IntId"].(float64)),
 					Name:       tc["Name"].(string),
 					NodeId:     tc["NodeId"].(string),

--- a/pkg/authorizer/claims.go
+++ b/pkg/authorizer/claims.go
@@ -1,6 +1,7 @@
 package authorizer
 
 import (
+	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/authorizer/models"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/organization"
@@ -22,21 +23,26 @@ const LabelServiceClaim = "service_claim"
 
 // Claims is an object containing claims and user info
 type Claims struct {
-	OrgClaim     organization.Claim
-	DatasetClaim dataset.Claim
-	UserClaim    user.Claim
-	TeamClaims   []teamUser.Claim
+	OrgClaim     *organization.Claim
+	DatasetClaim *dataset.Claim
+	UserClaim    *user.Claim
+	TeamClaims   []*teamUser.Claim
+}
+
+func (c *Claims) String() string {
+	return fmt.Sprintf("{ OrgClaim: %s, DatasetClaim: %s, UserClaim: %s, TeamClaims: %s }",
+		c.OrgClaim, c.DatasetClaim, c.UserClaim, c.TeamClaims)
 }
 
 // ParseClaims creates a Claims object from a string map which is returned by the authorizer.
 func ParseClaims(claims map[string]interface{}) *Claims {
 	log.WithFields(log.Fields{"service": "Authorizer", "function": "ParseClaims()", "claims": claims}).Debug()
 
-	var orgClaim organization.Claim
+	var orgClaim *organization.Claim
 	if val, ok := claims[LabelOrganizationClaim]; ok {
 		orgClaims := val.(map[string]interface{})
 		orgRole := int64(orgClaims["Role"].(float64))
-		orgClaim = organization.Claim{
+		orgClaim = &organization.Claim{
 			Role:            pgdb.DbPermission(orgRole),
 			IntId:           int64(orgClaims["IntId"].(float64)),
 			NodeId:          orgClaims["NodeId"].(string),
@@ -44,12 +50,12 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 		}
 	}
 
-	var datasetClaim dataset.Claim
+	var datasetClaim *dataset.Claim
 	if val, ok := claims[LabelDatasetClaim]; ok {
 		if val != nil {
 			datasetClaims := val.(map[string]interface{})
 			datasetRole := int64(datasetClaims["Role"].(float64))
-			datasetClaim = dataset.Claim{
+			datasetClaim = &dataset.Claim{
 				Role:   role.Role(datasetRole),
 				NodeId: datasetClaims["NodeId"].(string),
 				IntId:  int64(datasetClaims["IntId"].(float64)),
@@ -57,11 +63,11 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 		}
 	}
 
-	var userClaim user.Claim
+	var userClaim *user.Claim
 	if val, ok := claims[LabelUserClaim]; ok {
 		if val != nil {
 			userClaims := val.(map[string]interface{})
-			userClaim = user.Claim{
+			userClaim = &user.Claim{
 				Id:           int64(userClaims["Id"].(float64)),
 				NodeId:       userClaims["NodeId"].(string),
 				IsSuperAdmin: userClaims["IsSuperAdmin"].(bool),
@@ -69,13 +75,13 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 		}
 	}
 
-	var teamClaims []teamUser.Claim
+	var teamClaims []*teamUser.Claim
 	if val, ok := claims[LabelTeamClaims]; ok {
 		if val != nil {
 			tcs := val.([]interface{})
 			for _, item := range tcs {
 				tc := item.(map[string]interface{})
-				teamClaim := teamUser.Claim{
+				teamClaim := &teamUser.Claim{
 					IntId:      int64(tc["IntId"].(float64)),
 					Name:       tc["Name"].(string),
 					NodeId:     tc["NodeId"].(string),

--- a/pkg/authorizer/claims.go
+++ b/pkg/authorizer/claims.go
@@ -14,6 +14,12 @@ import (
 	"time"
 )
 
+const LabelUserClaim = "user_claim"
+const LabelOrganizationClaim = "org_claim"
+const LabelTeamClaims = "team_claims"
+const LabelDatasetClaim = "dataset_claim"
+const LabelServiceClaim = "service_claim"
+
 // Claims is an object containing claims and user info
 type Claims struct {
 	OrgClaim     organization.Claim
@@ -27,7 +33,7 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 	log.WithFields(log.Fields{"service": "Authorizer", "function": "ParseClaims()", "claims": claims}).Debug()
 
 	var orgClaim organization.Claim
-	if val, ok := claims["org_claim"]; ok {
+	if val, ok := claims[LabelOrganizationClaim]; ok {
 		orgClaims := val.(map[string]interface{})
 		orgRole := int64(orgClaims["Role"].(float64))
 		orgClaim = organization.Claim{
@@ -39,7 +45,7 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 	}
 
 	var datasetClaim dataset.Claim
-	if val, ok := claims["dataset_claim"]; ok {
+	if val, ok := claims[LabelDatasetClaim]; ok {
 		if val != nil {
 			datasetClaims := val.(map[string]interface{})
 			datasetRole := int64(datasetClaims["Role"].(float64))
@@ -52,7 +58,7 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 	}
 
 	var userClaim user.Claim
-	if val, ok := claims["user_claim"]; ok {
+	if val, ok := claims[LabelUserClaim]; ok {
 		if val != nil {
 			userClaims := val.(map[string]interface{})
 			userClaim = user.Claim{
@@ -64,7 +70,7 @@ func ParseClaims(claims map[string]interface{}) *Claims {
 	}
 
 	var teamClaims []teamUser.Claim
-	if val, ok := claims["team_claims"]; ok {
+	if val, ok := claims[LabelTeamClaims]; ok {
 		if val != nil {
 			tcs := val.([]interface{})
 			for _, item := range tcs {
@@ -135,7 +141,7 @@ func GenerateServiceClaim(duration time.Duration) models.ServiceClaim {
 	issuedTime := time.Now().Unix()
 	expiresAt := issuedTime + duration.Milliseconds()/1000
 	return models.ServiceClaim{
-		Type:      "service_claim",
+		Type:      LabelServiceClaim,
 		IssuedAt:  strconv.FormatInt(issuedTime, 10),
 		ExpiresAt: strconv.FormatInt(expiresAt, 10),
 	}

--- a/pkg/authorizer/claims_test.go
+++ b/pkg/authorizer/claims_test.go
@@ -33,7 +33,8 @@ func TestClaims(t *testing.T) {
 		"Service Claim as Token":              testServiceClaimAsToken,
 		"Nil Claims have no org role":         testNilClaimsHaveNoOrgRole,
 		"HasOrgRole":                          testHasOrgRole,
-		"BUG Failing to parse Team Claims":    testBugFailingToParseTeamClaims,
+		"BUG Failing to parse Team Claims":    testBugFailToParseTeamsClaim,
+		"Successfully parse Team Claims":      testBugSuccessfullyParseTeamClaims,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			fn(t)
@@ -266,8 +267,18 @@ func testHasOrgRole(t *testing.T) {
 	}
 }
 
-func testBugFailingToParseTeamClaims(t *testing.T) {
+func testBugFailToParseTeamsClaim(t *testing.T) {
 	input := []byte("{\n    \"claims\": {\n        \"org_claim\": {\n            \"EnabledFeatures\": [\n                {\n                    \"created_at\": \"2023-08-23T22:50:03.381715Z\",\n                    \"enabled\": true,\n                    \"feature\": \"publishing50_feature\",\n                    \"organization_id\": 39,\n                    \"updated_at\": \"2023-08-23T22:50:03.381715Z\"\n                }\n            ],\n            \"IntId\": 39,\n            \"NodeId\": \"N:organization:7c2de0a6-5972-4138-99ad-cc0aff0fb67f\",\n            \"Role\": 32\n        },\n        \"teams_claim\": [\n            {\n                \"IntId\": 91,\n                \"Name\": \"Publishers\",\n                \"NodeId\": \"N:team:3a616648-9ad0-4809-be63-8615f08babad\",\n                \"Permission\": 16,\n                \"TeamType\": \"publishers\"\n            }\n        ],\n        \"user_claim\": {\n            \"Id\": 177,\n            \"IsSuperAdmin\": true,\n            \"NodeId\": \"N:user:61e7c1cf-a836-421b-b919-a2309402c9d6\"\n        }\n    }\n}\n")
+	var claims map[string]interface{}
+	err := json.Unmarshal(input, &claims)
+	assert.NoError(t, err)
+	parsedClaims := ParseClaims(claims)
+	fmt.Println(parsedClaims)
+	assert.Nil(t, parsedClaims.TeamClaims)
+}
+
+func testBugSuccessfullyParseTeamClaims(t *testing.T) {
+	input := []byte("{\n    \"claims\": {\n        \"org_claim\": {\n            \"EnabledFeatures\": [\n                {\n                    \"created_at\": \"2023-08-23T22:50:03.381715Z\",\n                    \"enabled\": true,\n                    \"feature\": \"publishing50_feature\",\n                    \"organization_id\": 39,\n                    \"updated_at\": \"2023-08-23T22:50:03.381715Z\"\n                }\n            ],\n            \"IntId\": 39,\n            \"NodeId\": \"N:organization:7c2de0a6-5972-4138-99ad-cc0aff0fb67f\",\n            \"Role\": 32\n        },\n        \"team_claims\": [\n            {\n                \"IntId\": 91,\n                \"Name\": \"Publishers\",\n                \"NodeId\": \"N:team:3a616648-9ad0-4809-be63-8615f08babad\",\n                \"Permission\": 16,\n                \"TeamType\": \"publishers\"\n            }\n        ],\n        \"user_claim\": {\n            \"Id\": 177,\n            \"IsSuperAdmin\": true,\n            \"NodeId\": \"N:user:61e7c1cf-a836-421b-b919-a2309402c9d6\"\n        }\n    }\n}\n")
 	var claims map[string]interface{}
 	err := json.Unmarshal(input, &claims)
 	assert.NoError(t, err)

--- a/pkg/authorizer/claims_test.go
+++ b/pkg/authorizer/claims_test.go
@@ -1,6 +1,7 @@
 package authorizer
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/dataset"
@@ -32,6 +33,7 @@ func TestClaims(t *testing.T) {
 		"Service Claim as Token":              testServiceClaimAsToken,
 		"Nil Claims have no org role":         testNilClaimsHaveNoOrgRole,
 		"HasOrgRole":                          testHasOrgRole,
+		"BUG Failing to parse Team Claims":    testBugFailingToParseTeamClaims,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			fn(t)
@@ -262,4 +264,14 @@ func testHasOrgRole(t *testing.T) {
 
 		})
 	}
+}
+
+func testBugFailingToParseTeamClaims(t *testing.T) {
+	input := []byte("{\n    \"claims\": {\n        \"org_claim\": {\n            \"EnabledFeatures\": [\n                {\n                    \"created_at\": \"2023-08-23T22:50:03.381715Z\",\n                    \"enabled\": true,\n                    \"feature\": \"publishing50_feature\",\n                    \"organization_id\": 39,\n                    \"updated_at\": \"2023-08-23T22:50:03.381715Z\"\n                }\n            ],\n            \"IntId\": 39,\n            \"NodeId\": \"N:organization:7c2de0a6-5972-4138-99ad-cc0aff0fb67f\",\n            \"Role\": 32\n        },\n        \"teams_claim\": [\n            {\n                \"IntId\": 91,\n                \"Name\": \"Publishers\",\n                \"NodeId\": \"N:team:3a616648-9ad0-4809-be63-8615f08babad\",\n                \"Permission\": 16,\n                \"TeamType\": \"publishers\"\n            }\n        ],\n        \"user_claim\": {\n            \"Id\": 177,\n            \"IsSuperAdmin\": true,\n            \"NodeId\": \"N:user:61e7c1cf-a836-421b-b919-a2309402c9d6\"\n        }\n    }\n}\n")
+	var claims map[string]interface{}
+	err := json.Unmarshal(input, &claims)
+	assert.NoError(t, err)
+	parsedClaims := ParseClaims(claims)
+	fmt.Println(parsedClaims)
+	assert.NotNil(t, parsedClaims.TeamClaims)
 }

--- a/pkg/authorizer/models/models.go
+++ b/pkg/authorizer/models/models.go
@@ -26,7 +26,7 @@ type ServiceToken struct {
 	Value string `json:"value"`
 }
 
-func (c ServiceClaim) WithOrganizationClaim(claim organization.Claim) ServiceClaim {
+func (c ServiceClaim) WithOrganizationClaim(claim *organization.Claim) ServiceClaim {
 	c.Roles = append(c.Roles, ServiceRole{
 		Type:   "organization_role",
 		Id:     strconv.FormatInt(claim.IntId, 10),
@@ -36,7 +36,7 @@ func (c ServiceClaim) WithOrganizationClaim(claim organization.Claim) ServiceCla
 	return c
 }
 
-func (c ServiceClaim) WithDatasetClaim(claim dataset.Claim) ServiceClaim {
+func (c ServiceClaim) WithDatasetClaim(claim *dataset.Claim) ServiceClaim {
 	c.Roles = append(c.Roles, ServiceRole{
 		Type:   "dataset_role",
 		Id:     strconv.FormatInt(claim.IntId, 10),

--- a/pkg/models/dataset/models.go
+++ b/pkg/models/dataset/models.go
@@ -13,5 +13,5 @@ type Claim struct {
 }
 
 func (c Claim) String() string {
-	return fmt.Sprintf("%s (%d) - %s", c.NodeId, c.IntId, c.Role.String())
+	return fmt.Sprintf("{ Id: %d, NodeId: %s, Role: %d (%s) }", c.IntId, c.NodeId, c.Role, c.Role.String())
 }

--- a/pkg/models/organization/models.go
+++ b/pkg/models/organization/models.go
@@ -15,7 +15,8 @@ type Claim struct {
 }
 
 func (c Claim) String() string {
-	return fmt.Sprintf("OrganizationId: %d - %s", c.IntId, c.Role.String())
+	return fmt.Sprintf("{ Id: %d, NodeId: %s, Role: %d (%s), EnabledFeatures: %+v }",
+		c.IntId, c.NodeId, c.Role, c.Role.String(), c.EnabledFeatures)
 }
 
 // HasRole returns true if this claim contains permissions sufficient to satisfy the given requiredOrgRole

--- a/pkg/models/teamUser/models.go
+++ b/pkg/models/teamUser/models.go
@@ -14,6 +14,6 @@ type Claim struct {
 }
 
 func (c Claim) String() string {
-	return fmt.Sprintf("Name: %s (id: %d nodeId: %s permission: %d)",
-		c.Name, c.IntId, c.NodeId, c.Permission)
+	return fmt.Sprintf("{ Name: %s, Id: %d, NodeId: %s, Permission: %d (%s) }",
+		c.Name, c.IntId, c.NodeId, c.Permission, c.Permission.String())
 }

--- a/pkg/models/user/models.go
+++ b/pkg/models/user/models.go
@@ -12,5 +12,5 @@ type Claim struct {
 }
 
 func (c Claim) String() string {
-	return fmt.Sprintf("User: %d - %s | isSuperAdmin: %t", c.Id, c.NodeId, c.IsSuperAdmin)
+	return fmt.Sprintf("{ Id: %d, NodeId: %s, IsSuperAdmin: %t }", c.Id, c.NodeId, c.IsSuperAdmin)
 }


### PR DESCRIPTION
Change `Claims` to hold pointers to contained claims. This way the absence of a claim is a `nil` value instead of an empty stuct.

```go
type Claims struct {
	OrgClaim     *organization.Claim
	DatasetClaim *dataset.Claim
	UserClaim    *user.Claim
	TeamClaims   []*teamUser.Claim
}
```