### PR TITLE
Remove panics and log.Fatal* from non-test code

### DIFF
--- a/pkg/models/manifest/manifestFile/models.go
+++ b/pkg/models/manifest/manifestFile/models.go
@@ -105,7 +105,7 @@ type DTO struct {
 	FileName string `json:"file_name"`
 	FilePath string `json:"file_path"`
 	FileType string `json:"file_type"`
-	UploadId string `json:"upload_id""`
+	UploadId string `json:"upload_id"`
 	Status   string `json:"status"`
 	Icon     string `json:"icon"`
 }

--- a/pkg/models/manifest/models.go
+++ b/pkg/models/manifest/models.go
@@ -76,7 +76,7 @@ type GetStatusEndpointResponse struct {
 }
 
 type PostResponse struct {
-	ManifestNodeId string                       `json:"manifest_node_id"'`
+	ManifestNodeId string                       `json:"manifest_node_id"`
 	NrFilesUpdated int                          `json:"nr_files_updated"`
 	NrFilesRemoved int                          `json:"nr_files_removed"`
 	UpdatedFiles   []manifestFile.FileStatusDTO `json:"updated_files"`

--- a/pkg/queries/dydb/manifestFiles.go
+++ b/pkg/queries/dydb/manifestFiles.go
@@ -285,14 +285,14 @@ func (q *Queries) statusForFileItem(ctx context.Context, tableName string, manif
 
 	result, err := q.db.GetItem(ctx, getItemInput)
 	if err != nil {
-		log.Error("Error getting item from dydb")
+		return -1, fmt.Errorf("error getting manifest file status from dydb: %w", err)
 	}
 
 	var pItem dydb.ManifestFileTable
 	if len(result.Item) > 0 {
 		err = attributevalue.UnmarshalMap(result.Item, &pItem)
 		if err != nil {
-			log.Fatalf(err.Error())
+			return -1, fmt.Errorf("error unmarshalling manifest file item from dydb: %w", err)
 		}
 
 		var m manifestFile.Status
@@ -403,7 +403,8 @@ func (q *Queries) syncUpdate(ctx context.Context, fileTableName string, manifest
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, fmt.Errorf("error marshalling manifest file item: %w", err)
 			}
 			if len(isInProgress) == 0 {
 				delete(data, "InProgress")
@@ -453,7 +454,8 @@ func (q *Queries) syncUpdate(ctx context.Context, fileTableName string, manifest
 				log.Fields{
 					"manifest_id": manifestId,
 				},
-			).Fatalln("Unable to Batch Write: ", err)
+			).Error("Unable to Batch Write: ", err)
+			return nil, fmt.Errorf("error batch writing manifest file items: %w", err)
 		}
 
 		nrFilesUpdated += len(writeRequests) - len(data.UnprocessedItems)
@@ -477,7 +479,8 @@ func (q *Queries) syncUpdate(ctx context.Context, fileTableName string, manifest
 					log.Fields{
 						"manifest_id": manifestId,
 					},
-				).Fatalln("Unable to Batch Write: ", err)
+				).Error("Unable to Batch Write: ", err)
+				return nil, fmt.Errorf("error batch writing unprocessed manifest file items: %w", err)
 			}
 
 			nrFilesUpdated += len(unProcessedItems) - len(data.UnprocessedItems)
@@ -563,7 +566,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling manifest file item: %w", err)
 			}
 			delete(data, "InProgress")
 
@@ -591,7 +595,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling mainifest file primary key: %w", err)
 			}
 			request := types.WriteRequest{
 				DeleteRequest: &types.DeleteRequest{
@@ -618,7 +623,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling verified file manifest item: %w", err)
 			}
 			delete(data, "InProgress")
 
@@ -640,7 +646,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling registered manifest file item: %w", err)
 			}
 
 			request := types.WriteRequest{
@@ -668,7 +675,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling verified manifest file item: %w", err)
 			}
 			delete(data, "InProgress")
 
@@ -698,7 +706,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling registered manifest file item: %w", err)
 			}
 
 			request := types.WriteRequest{
@@ -720,7 +729,8 @@ func getWriteRequest(manifestId string, file manifestFile.FileDTO, curStatus man
 						"manifest_id": manifestId,
 						"upload_id":   file.UploadID,
 					},
-				).Fatalf("MarshalMap: %v\n", err)
+				).Errorf("MarshalMap: %v\n", err)
+				return nil, manifestFile.Unknown, fmt.Errorf("error marshalling curStatus manifest file item: %w", err)
 			}
 			delete(data, "InProgress")
 

--- a/pkg/queries/pgdb/contributors.go
+++ b/pkg/queries/pgdb/contributors.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-	log "github.com/sirupsen/logrus"
 	"strings"
 )
 
@@ -71,8 +70,7 @@ func scanContributor(row *sql.Row) (*pgdb.Contributor, error) {
 		case sql.ErrNoRows:
 			return nil, ContributorNotFoundError{err}
 		default:
-			log.Error("Unknown Error while scanning dataset row: ", err)
-			panic(err)
+			return nil, err
 		}
 	}
 	return &contributor, nil

--- a/pkg/queries/pgdb/dataUseAgreements.go
+++ b/pkg/queries/pgdb/dataUseAgreements.go
@@ -2,13 +2,12 @@ package pgdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-	log "github.com/sirupsen/logrus"
 )
 
 // GetDefaultDataUseAgreement will return the default data use agreement for the organization.
+// Returns (nil, sql.ErrNoRows) if no default data use agreement is found for the organization
 func (q *Queries) GetDefaultDataUseAgreement(ctx context.Context, organizationId int) (*pgdb.DataUseAgreement, error) {
 	query := fmt.Sprintf("SELECT id, name, body, created_at, is_default, description"+
 		" FROM \"%d\".data_use_agreements where is_default = true;", organizationId)
@@ -24,14 +23,7 @@ func (q *Queries) GetDefaultDataUseAgreement(ctx context.Context, organizationId
 		&dataUseAgreement.Description)
 
 	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			log.Error("No rows were returned!")
-			return nil, err
-		default:
-			log.Error("Unknown Error while scanning data_use_agreements table: ", err)
-			panic(err)
-		}
+		return nil, err
 	}
 
 	return &dataUseAgreement, nil

--- a/pkg/queries/pgdb/datasetStatus.go
+++ b/pkg/queries/pgdb/datasetStatus.go
@@ -2,14 +2,13 @@ package pgdb
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-	log "github.com/sirupsen/logrus"
 )
 
 // GetDefaultDatasetStatus will return the default dataset status for the organization.
 // This is assumed to be the dataset status row with the lowest id number.
+// Returns (nil, sql.ErrNoRows) if no dataset status is found for the organization
 func (q *Queries) GetDefaultDatasetStatus(ctx context.Context, organizationId int) (*pgdb.DatasetStatus, error) {
 	query := fmt.Sprintf("SELECT id, name, display_name, original_name, color, created_at, updated_at"+
 		" FROM \"%d\".dataset_status order by id limit 1;", organizationId)
@@ -26,14 +25,7 @@ func (q *Queries) GetDefaultDatasetStatus(ctx context.Context, organizationId in
 		&datasetStatus.UpdatedAt)
 
 	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			log.Error("No rows were returned!")
-			return nil, err
-		default:
-			log.Error("Unknown Error while scanning dataset_status table: ", err)
-			panic(err)
-		}
+		return nil, err
 	}
 
 	return &datasetStatus, nil

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -143,6 +143,7 @@ func (q *Queries) GetDatasets(ctx context.Context, organizationId int) ([]pgdb.D
 
 // GetDatasetClaim returns the highest role that the user has for a given dataset.
 // This method checks the roles of the dataset, the teams, and the specific user roles.
+// returns (nil, sql.ErrNoRows) if no dataset with the given nodeId is found
 func (q *Queries) GetDatasetClaim(ctx context.Context, user *pgdb.User, datasetNodeId string, organizationId int64) (*dataset.Claim, error) {
 
 	// if user is super-admin
@@ -166,14 +167,7 @@ func (q *Queries) GetDatasetClaim(ctx context.Context, user *pgdb.User, datasetN
 		&maybeDatasetRole)
 
 	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			log.Error("No rows were returned!")
-			return nil, err
-		default:
-			log.Error("Uknown Error while scanning dataset table: ", err)
-			panic(err)
-		}
+		return nil, err
 	}
 
 	// If maybeDatasetRole is set, include the role, otherwise use none-role
@@ -261,8 +255,7 @@ func (q *Queries) GetDatasetUser(ctx context.Context, dataset *pgdb.Dataset, use
 		case sql.ErrNoRows:
 			return nil, DatasetUserNotFoundError{fmt.Sprintf("%+v", err)}
 		default:
-			log.Error("Unknown Error while query/scan dataset user table: ", err)
-			panic(err)
+			return nil, err
 		}
 	}
 
@@ -384,8 +377,7 @@ func scanDataset(row *sql.Row) (*pgdb.Dataset, error) {
 		case sql.ErrNoRows:
 			return nil, DatasetNotFoundError{"No rows were returned!"}
 		default:
-			log.Error("Unknown Error while scanning dataset row: ", err)
-			panic(err)
+			return nil, err
 		}
 	}
 

--- a/pkg/queries/pgdb/datasets.go
+++ b/pkg/queries/pgdb/datasets.go
@@ -176,7 +176,7 @@ func (q *Queries) GetDatasetClaim(ctx context.Context, user *pgdb.User, datasetN
 		var ok bool
 		datasetRole, ok = role.RoleFromString(maybeDatasetRole.String)
 		if !ok {
-			log.Fatalln("Could not map Dataset Role from database string: ", maybeDatasetRole.String)
+			return nil, fmt.Errorf("error mapping Dataset Role from database string: %s", maybeDatasetRole.String)
 		}
 	}
 
@@ -215,7 +215,7 @@ func (q *Queries) GetDatasetClaim(ctx context.Context, user *pgdb.User, datasetN
 
 		role, ok := role.RoleFromString(roleString)
 		if !ok {
-			log.Fatalln("Could not map Dataset Role from database string.")
+			return nil, fmt.Errorf("error mapping Dataset Role from database string: %s", roleString)
 		}
 		roles = append(roles, role)
 	}

--- a/pkg/queries/pgdb/datasets_test.go
+++ b/pkg/queries/pgdb/datasets_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/role"
 	"github.com/pennsieve/pennsieve-go-core/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -121,13 +122,9 @@ func testGetDatasetByName(t *testing.T, store *SQLStore, orgId int) {
 func testCreateDataset(t *testing.T, store *SQLStore, orgId int) {
 	var err error
 	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default dataset status")
-	}
+	require.NoErrorf(t, err, "testCreateDataset(): failed to get default dataset status")
 	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
-	}
+	require.NoErrorf(t, err, "testCreateDataset(): failed to get default data use agreement")
 	createDatasetParams := CreateDatasetParams{
 		Name:                         "Test Dataset - CreateDataset",
 		Description:                  "Test Dataset - CreateDataset",
@@ -233,13 +230,9 @@ func testAddManagerToDataset(t *testing.T, store *SQLStore, orgId int) {
 func testUnspecifiedLicenseIsNull(t *testing.T, store *SQLStore, orgId int) {
 	var err error
 	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default dataset status")
-	}
+	require.NoErrorf(t, err, "testUnspecifiedLicenseIsNull(): failed to get default dataset status")
 	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
-	}
+	require.NoErrorf(t, err, "testUnspecifiedLicenseIsNull(): failed to get default data use agreement")
 	createDatasetParams := CreateDatasetParams{
 		Name:                         "Test Dataset - UnspecifiedLicenseIsNull",
 		Description:                  "Test Dataset - UnspecifiedLicenseIsNull",
@@ -257,13 +250,9 @@ func testUnspecifiedLicenseIsNull(t *testing.T, store *SQLStore, orgId int) {
 func testEmptyStringLicenseIsNull(t *testing.T, store *SQLStore, orgId int) {
 	var err error
 	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default dataset status")
-	}
+	require.NoErrorf(t, err, "testEmptyStringLicenseIsNull(): failed to get default dataset status")
 	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDataset(): failed to get default data use agreement")
-	}
+	require.NoErrorf(t, err, "testEmptyStringLicenseIsNull(): failed to get default data use agreement")
 	createDatasetParams := CreateDatasetParams{
 		Name:                         "Test Dataset - EmptyStringLicenseIsNull",
 		Description:                  "Test Dataset - EmptyStringLicenseIsNull",
@@ -295,13 +284,9 @@ func testUpdatedAtChange(t *testing.T, store *SQLStore, orgId int) {
 func testDefaultDatasetType(t *testing.T, store *SQLStore, orgId int) {
 	var err error
 	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testDefaultDatasetType(): failed to get default dataset status")
-	}
+	require.NoErrorf(t, err, "testDefaultDatasetType(): failed to get default dataset status")
 	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testDefaultDatasetType(): failed to get default data use agreement")
-	}
+	require.NoErrorf(t, err, "testDefaultDatasetType(): failed to get default data use agreement")
 	createDatasetParams := CreateDatasetParams{
 		Name:                         "Test Default Dataset type is research",
 		Description:                  "Test Default Dataset type is research - description",
@@ -320,13 +305,9 @@ func testDefaultDatasetType(t *testing.T, store *SQLStore, orgId int) {
 func testCreateDatasetTypeRelease(t *testing.T, store *SQLStore, orgId int) {
 	var err error
 	defaultDatasetStatus, err := store.GetDefaultDatasetStatus(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDatasetTypeRelease(): failed to get default dataset status")
-	}
+	require.NoErrorf(t, err, "testCreateDatasetTypeRelease(): failed to get default dataset status")
 	defaultDataUseAgreement, err := store.GetDefaultDataUseAgreement(context.TODO(), orgId)
-	if err != nil {
-		fmt.Errorf("testCreateDatasetTypeRelease(): failed to get default data use agreement")
-	}
+	require.NoErrorf(t, err, "testCreateDatasetTypeRelease(): failed to get default data use agreement")
 	createDatasetParams := CreateDatasetParams{
 		Name:                         "Test Dataset type is release",
 		Description:                  "Test Dataset type is release - description",

--- a/pkg/queries/pgdb/db.go
+++ b/pkg/queries/pgdb/db.go
@@ -43,7 +43,9 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 func (q *Queries) ShowSearchPath(loc string) {
 	var currentSchema string
 	rr := q.db.QueryRowContext(context.Background(), "show search_path")
-	rr.Scan(&currentSchema)
+	if err := rr.Scan(&currentSchema); err != nil {
+		log.Error("ignoring 'show search_path' error: ", err)
+	}
 	fmt.Printf("%s: Search Path: %v\n", loc, currentSchema)
 }
 

--- a/pkg/queries/pgdb/db.go
+++ b/pkg/queries/pgdb/db.go
@@ -82,13 +82,13 @@ func ConnectRDS() (*sql.DB, error) {
 
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		panic("configuration error: " + err.Error())
+		return nil, fmt.Errorf("error loading AWS config: %w", err)
 	}
 
 	authenticationToken, err := auth.BuildAuthToken(
 		context.TODO(), dbEndpoint, region, dbUser, cfg.Credentials)
 	if err != nil {
-		panic("failed to create authentication token: " + err.Error())
+		return nil, fmt.Errorf("error building RDS auth token: %w", err)
 	}
 
 	return connect(dbHost, strconv.Itoa(dbPort), dbUser, authenticationToken, dbName, "")
@@ -152,12 +152,12 @@ func connect(dbHost string, dbPort string, dbUser string, authenticationToken st
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("error opening DB connection: %w", err)
 	}
 
 	err = db.Ping()
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("error pinging DB connection: %w", err)
 	}
 
 	return db, err

--- a/pkg/queries/pgdb/organizations.go
+++ b/pkg/queries/pgdb/organizations.go
@@ -2,11 +2,10 @@ package pgdb
 
 import (
 	"context"
-	"database/sql"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-	log "github.com/sirupsen/logrus"
 )
 
+// getOrganization returns (nil, sql.ErrNoRows) if no Organization is found
 func (q *Queries) getOrganization(ctx context.Context, query string, value any) (*pgdb.Organization, error) {
 	var organization pgdb.Organization
 	row := q.db.QueryRowContext(ctx, query, value)
@@ -21,15 +20,10 @@ func (q *Queries) getOrganization(ctx context.Context, query string, value any) 
 		&organization.CreatedAt,
 		&organization.UpdatedAt)
 
-	switch err {
-	case sql.ErrNoRows:
-		log.Error("No rows were returned!")
+	if err != nil {
 		return nil, err
-	case nil:
-		return &organization, nil
-	default:
-		panic(err)
 	}
+	return &organization, nil
 }
 
 // GetOrganization returns a single organization

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -51,7 +51,7 @@ func (q *Queries) AddFolder(ctx context.Context, r pgdb.PackageParams) (*pgdb.Pa
 	//prepare the statement
 	stmt, err := q.db.PrepareContext(ctx, sqlInsert)
 	if err != nil {
-		log.Fatalln("ERROR: ", err)
+		return nil, fmt.Errorf("error preparing addFolder statement: %w", err)
 	}
 	//goland:noinspection ALL
 	defer stmt.Close()
@@ -228,8 +228,8 @@ func (q *Queries) GetPackageByNodeId(ctx context.Context, nodeId string) (*pgdb.
 }
 
 // GetPackageAncestorIds returns an array of Package Ids corresponding with the ancestor Package Ids for the provided package.
-// 	- resulting array includes requested package Id as first entry
-//  - resulting array includes first folder in dataset as last entry if package is in nested folder
+//   - resulting array includes requested package Id as first entry
+//   - resulting array includes first folder in dataset as last entry if package is in nested folder
 func (q *Queries) GetPackageAncestorIds(ctx context.Context, packageId int64) ([]int64, error) {
 
 	queryStr := "" +
@@ -272,7 +272,7 @@ func (q *Queries) GetPackageAncestorIds(ctx context.Context, packageId int64) ([
 
 // PRIVATE
 // AddPackages runs the query to insert a set of packages that belong to the same parent folder.
-// 	- If adding packages to root-folder, the parentId should be set to -1
+//   - If adding packages to root-folder, the parentId should be set to -1
 //
 // It returns two arrays:
 //  1. successfully created packages,
@@ -350,7 +350,7 @@ func (q *Queries) addPackageByParent(ctx context.Context, parentId int64, record
 	// prepare the statement
 	stmt, err := q.db.PrepareContext(ctx, sqlInsert)
 	if err != nil {
-		log.Fatalln("ERROR: ", err)
+		return nil, nil, fmt.Errorf("error preparing addPackageByParent statement: %w", err)
 	}
 	//goland:noinspection GoUnhandledErrorResult
 	defer stmt.Close()

--- a/pkg/queries/pgdb/tokens.go
+++ b/pkg/queries/pgdb/tokens.go
@@ -2,13 +2,12 @@ package pgdb
 
 import (
 	"context"
-	"database/sql"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-	log "github.com/sirupsen/logrus"
 )
 
 // GetTokenByCognitoId returns a user from Postgress based on his/her cognito-id
 // This function also returns the preferred org and whether the user is a super-admin.
+// Returns (nil, sql.ErrNoRows) if no user with the given cognito id exists.
 func (q *Queries) GetTokenByCognitoId(ctx context.Context, id string) (*pgdb.Token, error) {
 
 	queryStr := "SELECT id, name, token, organization_id, user_id, cognito_id, last_used, created_at, updated_at " +
@@ -27,18 +26,14 @@ func (q *Queries) GetTokenByCognitoId(ctx context.Context, id string) (*pgdb.Tok
 		&token.CreatedAt,
 		&token.UpdatedAt)
 
-	switch err {
-	case sql.ErrNoRows:
-		log.Error("No rows were returned!")
+	if err != nil {
 		return nil, err
-	case nil:
-		return &token, nil
-	default:
-		panic(err)
 	}
+	return &token, nil
 }
 
 // GetUserByCognitoId returns a Pennsieve User based on the cognito id in the token pool.
+// Returns (nil, sql.ErrNoRows) if no user with the given token exists
 func (q *Queries) GetUserByCognitoId(ctx context.Context, id string) (*pgdb.User, error) {
 
 	queryStr := "SELECT pennsieve.users.id, pennsieve.users.node_id, email, first_name, last_name, is_super_admin, pennsieve.tokens.organization_id as preferred_org_id " +
@@ -55,13 +50,8 @@ func (q *Queries) GetUserByCognitoId(ctx context.Context, id string) (*pgdb.User
 		&user.IsSuperAdmin,
 		&user.PreferredOrg)
 
-	switch err {
-	case sql.ErrNoRows:
-		log.Errorf("No rows were returned!")
+	if err != nil {
 		return nil, err
-	case nil:
-		return &user, nil
-	default:
-		panic(err)
 	}
+	return &user, nil
 }

--- a/pkg/queries/pgdb/users.go
+++ b/pkg/queries/pgdb/users.go
@@ -2,13 +2,12 @@ package pgdb
 
 import (
 	"context"
-	"database/sql"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
-	log "github.com/sirupsen/logrus"
 )
 
-//GetByCognitoId returns a user from Postgress based on his/her cognito-id
-//This function also returns the preferred org and whether the user is a super-admin.
+// GetByCognitoId returns a user from Postgress based on his/her cognito-id
+// This function also returns the preferred org and whether the user is a super-admin.
+// Returns (nil, sql.ErrNoRows) if no user with the given cognito id exists
 func (q *Queries) GetByCognitoId(ctx context.Context, id string) (*pgdb.User, error) {
 
 	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, COALESCE(preferred_org_id, -1) as preferred_org_id " +
@@ -25,19 +24,15 @@ func (q *Queries) GetByCognitoId(ctx context.Context, id string) (*pgdb.User, er
 		&user.IsSuperAdmin,
 		&user.PreferredOrg)
 
-	switch err {
-	case sql.ErrNoRows:
-		log.Error("No rows were returned!")
+	if err != nil {
 		return nil, err
-	case nil:
-		return &user, nil
-	default:
-		panic(err)
 	}
+	return &user, nil
 }
 
 // GetUserById returns a user from Postgres based on the user's int id
 // This function also returns the preferred org and whether the user is a super-admin.
+// Returns (nil, sql.ErrNoRows) if no user with the given id exists.
 func (q *Queries) GetUserById(ctx context.Context, id int64) (*pgdb.User, error) {
 
 	queryStr := "SELECT id, node_id, email, first_name, last_name, is_super_admin, COALESCE(preferred_org_id, -1) as preferred_org_id " +
@@ -54,13 +49,8 @@ func (q *Queries) GetUserById(ctx context.Context, id int64) (*pgdb.User, error)
 		&user.IsSuperAdmin,
 		&user.PreferredOrg)
 
-	switch err {
-	case sql.ErrNoRows:
-		log.Error("No rows were returned!")
+	if err != nil {
 		return nil, err
-	case nil:
-		return &user, nil
-	default:
-		panic(err)
 	}
+	return &user, nil
 }


### PR DESCRIPTION
PR for ticket: https://app.clickup.com/t/868b52h81. Idea is that as a shared library, pennsieve-go-core should not be panicking or ending processes via `log.Fatal*` in response to normal errors. These errors should be passed to the caller to handle. (PR also mostly assumes the caller is responsible for logging the error.) For example, in order to handle expired RDS auth token expiration, we may need to re-try Postgres queries which is impossible (or made more difficult) if this library panics. These methods/functions were already defined to have an error return value, so PR does not change any signatures.

#### Replaces calls to `panic` with returning `error`s. 
These panics are in our code that uses `database/sql` to query Postgres. In many cases, we were checking if the error was `sql.ErrNoRows` and either returning that error or another, more domain specific no-X-found-error. And otherwise we called `panic`. 

PR maintains the status quo for `sql.ErrNoRows` and "no-X-found-error", and otherwise just returns the `error` unchanged. 

Also removed some logging of these errors since the caller should be responsible for logging the error.

#### Replaces calls to `log.Fatal*` with returning `error`s. 
Same as above, but the `Fatal` calls are in both Postgres and DynamoDB related code. Here there was also logging which seems more helpful than in the panic cases, so PR keeps those log calls moving them from Fatal to Error.

PR also fixes a few unrelated typos that `go vet ./...` found.

