### PR TITLE
Add Published field to File

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -58,7 +58,7 @@ services:
       - core-tests
 
   pennsievedb:
-    image: pennsieve/pennsievedb:V20241024144839-seed
+    image: pennsieve/pennsievedb:V20260112110611-seed
     restart: always
     ports:
       - "5432:5432"
@@ -66,7 +66,7 @@ services:
       - core-tests
 
   pennsievedb-ci:
-    image: pennsieve/pennsievedb:V20241024144839-seed
+    image: pennsieve/pennsievedb:V20260112110611-seed
     restart: always
     networks:
       - core-tests

--- a/pkg/changelog/models.go
+++ b/pkg/changelog/models.go
@@ -1,7 +1,7 @@
 package changelog
 
 import (
-	"bytes"
+	"fmt"
 	"time"
 )
 
@@ -14,24 +14,42 @@ const (
 	RestorePackage
 )
 
-func (s Type) MarshalJSON() ([]byte, error) {
-	buffer := bytes.NewBufferString(`"`)
-	buffer.WriteString(s.String())
-	buffer.WriteString(`"`)
-	return buffer.Bytes(), nil
+const (
+	createPackageString  = "CREATE_PACKAGE"
+	deletePackageString  = "DELETE_PACKAGE"
+	restorePackageString = "RESTORE_PACKAGE"
+	unknownTypeString    = "UNKNOWN"
+)
+
+func (s Type) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s *Type) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case createPackageString:
+		*s = CreatePackage
+	case deletePackageString:
+		*s = DeletePackage
+	case restorePackageString:
+		*s = RestorePackage
+	default:
+		return fmt.Errorf("unknown changelog type: %s", text)
+	}
+	return nil
 }
 
 func (s Type) String() string {
 	switch s {
 	case CreatePackage:
-		return "CREATE_PACKAGE"
+		return createPackageString
 	case DeletePackage:
-		return "DELETE_PACKAGE"
+		return deletePackageString
 	case RestorePackage:
-		return "RESTORE_PACKAGE"
+		return restorePackageString
 	}
 
-	return "UNKNOWN"
+	return unknownTypeString
 }
 
 type MessageParams struct {

--- a/pkg/changelog/models_test.go
+++ b/pkg/changelog/models_test.go
@@ -1,0 +1,158 @@
+package changelog
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestType_MarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		t        Type
+		expected string
+	}{
+		{"CreatePackage", CreatePackage, "CREATE_PACKAGE"},
+		{"DeletePackage", DeletePackage, "DELETE_PACKAGE"},
+		{"RestorePackage", RestorePackage, "RESTORE_PACKAGE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.t.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestType_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Type
+	}{
+		{"CREATE_PACKAGE", "CREATE_PACKAGE", CreatePackage},
+		{"DELETE_PACKAGE", "DELETE_PACKAGE", DeletePackage},
+		{"RESTORE_PACKAGE", "RESTORE_PACKAGE", RestorePackage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result Type
+			err := result.UnmarshalText([]byte(tt.input))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestType_UnmarshalText_Unknown(t *testing.T) {
+	var result Type
+	err := result.UnmarshalText([]byte("INVALID_TYPE"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown changelog type")
+}
+
+func TestMessage_Marshal(t *testing.T) {
+	timestamp := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	msg := Message{
+		DatasetChangelogEventJob: MessageParams{
+			OrganizationId: 1,
+			DatasetId:      2,
+			UserId:         "user-123",
+			TraceId:        "trace-456",
+			Id:             "msg-789",
+			Events: []Event{
+				{
+					EventType: RestorePackage,
+					EventDetail: PackageRestoreEvent{
+						Id:     100,
+						Name:   "restored-package",
+						NodeId: "N:package:abc",
+					},
+					Timestamp: timestamp,
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), `"eventType":"RESTORE_PACKAGE"`)
+	assert.Contains(t, string(data), `"datasetId":2`)
+	assert.Contains(t, string(data), `"userId":"user-123"`)
+}
+
+func TestMessage_Unmarshal(t *testing.T) {
+	jsonStr := `{
+		"DatasetChangelogEventJob": {
+			"organizationId": 1,
+			"datasetId": 2,
+			"userId": "user-123",
+			"traceId": "trace-456",
+			"id": "msg-789",
+			"events": [
+				{
+					"eventType": "RESTORE_PACKAGE",
+					"eventDetail": {
+						"id": 100,
+						"name": "restored-package",
+						"nodeId": "N:package:abc"
+					},
+					"timestamp": "2024-01-15T10:30:00Z"
+				}
+			]
+		}
+	}`
+
+	var msg Message
+	err := json.Unmarshal([]byte(jsonStr), &msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), msg.DatasetChangelogEventJob.OrganizationId)
+	assert.Equal(t, int64(2), msg.DatasetChangelogEventJob.DatasetId)
+	assert.Equal(t, "user-123", msg.DatasetChangelogEventJob.UserId)
+	assert.Len(t, msg.DatasetChangelogEventJob.Events, 1)
+	assert.Equal(t, RestorePackage, msg.DatasetChangelogEventJob.Events[0].EventType)
+
+	// EventDetail is map[string]interface{} since we didn't implement custom unmarshalling
+	detail := msg.DatasetChangelogEventJob.Events[0].EventDetail.(map[string]interface{})
+	assert.Equal(t, float64(100), detail["id"]) // JSON numbers unmarshal as float64
+	assert.Equal(t, "restored-package", detail["name"])
+}
+
+func TestMessage_RoundTrip(t *testing.T) {
+	timestamp := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	original := Message{
+		DatasetChangelogEventJob: MessageParams{
+			OrganizationId: 1,
+			DatasetId:      2,
+			UserId:         "user-123",
+			TraceId:        "trace-456",
+			Id:             "msg-789",
+			Events: []Event{
+				{
+					EventType:   RestorePackage,
+					EventDetail: map[string]interface{}{"id": float64(100), "name": "test"},
+					Timestamp:   timestamp,
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var unmarshalled Message
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.DatasetChangelogEventJob.OrganizationId, unmarshalled.DatasetChangelogEventJob.OrganizationId)
+	assert.Equal(t, original.DatasetChangelogEventJob.DatasetId, unmarshalled.DatasetChangelogEventJob.DatasetId)
+	assert.Equal(t, original.DatasetChangelogEventJob.Events[0].EventType, unmarshalled.DatasetChangelogEventJob.Events[0].EventType)
+}

--- a/pkg/models/pgdb/fileTable.go
+++ b/pkg/models/pgdb/fileTable.go
@@ -24,6 +24,7 @@ type File struct {
 	UploadedState   uploadState.UploadedState       `json:"uploaded_state"`
 	CreatedAt       time.Time                       `json:"created_at"`
 	UpdatedAt       time.Time                       `json:"updated_at"`
+	Published       bool                            `json:"published"`
 }
 
 type FileParams struct {

--- a/pkg/queries/pgdb/files.go
+++ b/pkg/queries/pgdb/files.go
@@ -50,7 +50,7 @@ func (q *Queries) AddFiles(ctx context.Context, files []pgdb.FileParams) ([]pgdb
 		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at) VALUES "
 
 	returnRows := "id, package_id, name, file_type, s3_bucket, s3_key, " +
-		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at"
+		"object_type, size, checksum, uuid, processing_state, uploaded_state, created_at, updated_at, published"
 
 	sqlInsert = sqlInsert +
 		strings.Join(inserts, ",") +
@@ -99,6 +99,7 @@ func (q *Queries) AddFiles(ctx context.Context, files []pgdb.FileParams) ([]pgdb
 			&uState,
 			&currentRecord.CreatedAt,
 			&currentRecord.UpdatedAt,
+			&currentRecord.Published,
 		)
 
 		if err != nil {

--- a/pkg/queries/pgdb/files_test.go
+++ b/pkg/queries/pgdb/files_test.go
@@ -76,6 +76,7 @@ func testAddFilesDuplicateUUID(t *testing.T, store *SQLStore, orgId int, package
 		assert.NotEmpty(t, actualFileId)
 		actualFileUpdatedAt = actualFiles[0].UpdatedAt
 		assert.NotEmpty(t, actualFileUpdatedAt)
+		assert.False(t, actualFiles[0].Published)
 	}
 	duplicateFiles, err := store.AddFiles(context.Background(), files)
 	if assert.NoError(t, err) {
@@ -86,6 +87,7 @@ func testAddFilesDuplicateUUID(t *testing.T, store *SQLStore, orgId int, package
 		assert.Equal(t, uuid, duplicateFile.UUID)
 		assert.Equal(t, actualFileId, duplicateFile.Id)
 		assert.True(t, actualFileUpdatedAt.Before(duplicateFile.UpdatedAt))
+		assert.False(t, duplicateFiles[0].Published)
 	}
 }
 
@@ -118,6 +120,7 @@ func testAddFilesDuplicateUUIDDifferentS3Key(t *testing.T, store *SQLStore, orgI
 		actualInitialFileId = actualInitialFile.Id
 		assert.NotEmpty(t, actualInitialFileId)
 		actualInitialUpdatedAt = actualInitialFile.UpdatedAt
+		assert.False(t, actualInitialFiles[0].Published)
 	}
 
 	mistakeFile := pgdb.FileParams{


### PR DESCRIPTION
Updates the test Pennsieve DB version to latest version which includes the `published` column on the `files` table.

Adds `Published` field to `pgdb.File` model to capture new column. Also includes this new column in the values returned by `AddFiles` even though this will always be false in this case.

Does not add `Published` to `FileParams` because I think this is only used for input when creating new files which should not be setting published anyway. 

Implements and tests unmarshal for `changelog.Type`. This is mostly helpful for testing if you want to unmarshal a message that a mock receives into a `changelog.Message` struct which is currently impossible because of the missing custom unmarshaller for `Type`. Switched `Type` from `MarshalJSON()` to `(M|Unm)arshalText()` for the more straightforward implementation.