### PR TITLE
Add FailedOrphan status + fix IsInProgress terminal set

### DIFF
--- a/pkg/models/manifest/manifestFile/models.go
+++ b/pkg/models/manifest/manifestFile/models.go
@@ -7,18 +7,20 @@ type Status int64
 // Local --> Registered --> Removed -->  <Deleted>
 // Local --> Registered --> Changed --> Synced --> Uploaded --> Imported ....
 // Local --> Registered --> Uploaded --> Failed
+// Local --> Registered --> FailedOrphan (reconciler: object missing in S3)
 
 const (
-	Local      Status = iota // set when client creates upload (local only)
-	Registered               // set when client syncs with server (local, server)
-	Imported                 // set when uploader imported file (local, server)
-	Finalized                // set when importer moves file to final destination (local, server)
-	Verified                 // set when client is informed of finalized status (local, server)
-	Failed                   // set when importer fails to import (local, server)
-	Removed                  // set when client removes file locally (local only)
-	Unknown                  // set when sync failed (local only)
-	Changed                  // set when synced file is updated locally (local only)
-	Uploaded                 // set when file has successfully been uploaded to server (local only)
+	Local        Status = iota // set when client creates upload (local only)
+	Registered                 // set when client syncs with server (local, server)
+	Imported                   // set when uploader imported file (local, server)
+	Finalized                  // set when importer moves file to final destination (local, server)
+	Verified                   // set when client is informed of finalized status (local, server)
+	Failed                     // set when importer fails to import (local, server)
+	Removed                    // set when client removes file locally (local only)
+	Unknown                    // set when sync failed (local only)
+	Changed                    // set when synced file is updated locally (local only)
+	Uploaded                   // set when file has successfully been uploaded to server (local only)
+	FailedOrphan               // set by server-side reconciler when a Registered file's S3 object is confirmed missing past the grace period (server-originated terminal)
 )
 
 // String returns string version of FileStatus object.
@@ -44,20 +46,42 @@ func (s Status) String() string {
 		return "Changed"
 	case Uploaded:
 		return "Uploaded"
+	case FailedOrphan:
+		return "FailedOrphan"
 	default:
 		return "Initiated"
 	}
 }
 
-// IsInProgress returns a boolean indicating whether upload status reflects a finalized status
+// IsInProgress returns "x" when a file's status still expects more automatic
+// activity (so it should appear in the sparse InProgressIndex and keep its
+// manifest in a non-Completed state), and "" when the file has reached a
+// terminal state that no background worker will change on its own.
+//
+// Terminal set:
+//
+//   - Imported, Finalized, Verified — successful import pipeline stages.
+//   - Removed                       — explicitly dropped from the manifest.
+//   - Failed                        — import hit an unrecoverable error;
+//     no automatic retry mechanism drives it forward.
+//   - FailedOrphan                  — server-side reconciler confirmed the
+//     S3 object is missing; terminal unless the client explicitly re-syncs
+//     (which is an operator-triggered state transition, not automatic).
+//
+// Non-terminal (in progress): Local, Registered, Uploaded, Changed, Unknown.
 func (s Status) IsInProgress() string {
-	if s == Imported || s == Verified || s == Finalized || s == Removed {
+	switch s {
+	case Imported, Verified, Finalized, Removed, Failed, FailedOrphan:
 		return ""
 	}
 	return "x"
 }
 
 // ManifestFileStatusMap maps string values to FileStatus objects.
+//
+// Unknown strings map to Unknown (not Local) so callers don't misinterpret a
+// future-version status as "file hasn't been synced yet" and kick off a
+// spurious re-upload.
 func (s Status) ManifestFileStatusMap(value string) Status {
 	switch value {
 	case "Local":
@@ -80,8 +104,10 @@ func (s Status) ManifestFileStatusMap(value string) Status {
 		return Uploaded
 	case "Unknown":
 		return Unknown
+	case "FailedOrphan":
+		return FailedOrphan
 	}
-	return Local
+	return Unknown
 }
 
 // FileDTO used to transfer file object in API requests.

--- a/pkg/models/manifest/manifestFile/models_test.go
+++ b/pkg/models/manifest/manifestFile/models_test.go
@@ -1,0 +1,54 @@
+package manifestFile
+
+import "testing"
+
+func TestIsInProgress(t *testing.T) {
+	cases := []struct {
+		status   Status
+		expected string
+	}{
+		// Non-terminal — still expects automatic progress.
+		{Local, "x"},
+		{Registered, "x"},
+		{Uploaded, "x"},
+		{Changed, "x"},
+		{Unknown, "x"},
+
+		// Terminal — no background worker will change this automatically.
+		{Imported, ""},
+		{Finalized, ""},
+		{Verified, ""},
+		{Removed, ""},
+		{Failed, ""},
+		{FailedOrphan, ""},
+	}
+	for _, c := range cases {
+		if got := c.status.IsInProgress(); got != c.expected {
+			t.Errorf("IsInProgress(%s) = %q, want %q", c.status, got, c.expected)
+		}
+	}
+}
+
+func TestStatusStringRoundTrip(t *testing.T) {
+	// Every defined Status must round-trip via String() -> ManifestFileStatusMap.
+	all := []Status{Local, Registered, Imported, Finalized, Verified, Failed, Removed, Unknown, Changed, Uploaded, FailedOrphan}
+	for _, s := range all {
+		parsed := Status(0).ManifestFileStatusMap(s.String())
+		if parsed != s {
+			t.Errorf("round-trip failed: %s -> %q -> %s", s, s.String(), parsed)
+		}
+	}
+}
+
+func TestManifestFileStatusMapUnknownFallback(t *testing.T) {
+	// Unknown strings must map to Unknown, not Local. Previously mapping to
+	// Local caused callers (notably the agent) to misinterpret a
+	// future-version status as "not yet synced" and queue a spurious
+	// re-upload.
+	if got := Status(0).ManifestFileStatusMap("SomeFutureStatus"); got != Unknown {
+		t.Errorf("expected Unknown fallback for unknown string, got %s", got)
+	}
+	if got := Status(0).ManifestFileStatusMap(""); got != Unknown {
+		t.Errorf("expected Unknown fallback for empty string, got %s", got)
+	}
+}


### PR DESCRIPTION
New `FailedOrphan` status signals a file the server-side reconciler has confirmed missing in S3 past the grace period. It's the terminal state for case-B orphans (agent reported upload but the object never arrived or was never persisted).

Consequences to existing semantics:

  * `Failed` is now also in the terminal set. The previous behavior left Failed files counted as "in progress" via IsInProgress, which kept their manifests stuck in a pre-Completed state forever — no background worker advances Failed so that was effectively a bug. Treating Failed (and FailedOrphan) as terminal means a manifest whose remaining files are all terminal (success or failure) correctly transitions to Completed; the UI is expected to surface per-file success/failure independently of manifest-level status.

  * `ManifestFileStatusMap` now falls back to `Unknown` instead of `Local` for unrecognized status strings. The old `Local` fallback would cause a future-version agent to treat a new status as "not yet synced" and queue a spurious re-upload; `Unknown` is the safer default and matches the intent of the enum value.

Wire-format backward compatibility: `Status` is `type Status int64` serialized over JSON as an integer. `FailedOrphan` is appended at the end of the iota block (value 10), so existing client code that doesn't know about it will receive the new integer and:
  - IsInProgress returns "x" (defensive — treats unknown as in-progress)
  - String returns "Initiated" (cosmetic, appears in logs only)
  - SyncResponseStatusUpdate-style loops over known statuses silently skip the file (local sqlite unchanged; no destructive action)

Added tests cover the terminal-set invariant, a round-trip check for every defined Status, and the Unknown fallback for unrecognized strings.