### PR TITLE
Add onConflict strategy to AddPackages

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -58,7 +58,7 @@ services:
       - core-tests
 
   pennsievedb:
-    image: pennsieve/pennsievedb:V20260304122946-seed
+    image: pennsieve/pennsievedb:V20260419000000-seed
     restart: always
     ports:
       - "5432:5432"
@@ -66,7 +66,7 @@ services:
       - core-tests
 
   pennsievedb-ci:
-    image: pennsieve/pennsievedb:V20260304122946-seed
+    image: pennsieve/pennsievedb:V20260419000000-seed
     restart: always
     networks:
       - core-tests

--- a/pkg/models/packageInfo/conflictStrategy/models.go
+++ b/pkg/models/packageInfo/conflictStrategy/models.go
@@ -1,0 +1,23 @@
+package conflictStrategy
+
+// Strategy controls how AddPackagesWithConflict resolves a name collision
+// between a new upload and an existing non-deleted package under the same
+// (dataset_id, parent_id, name) tuple.
+type Strategy string
+
+const (
+	// KeepBoth appends " (N)" to the new upload's name so the existing
+	// package survives unchanged. This is the legacy behavior.
+	KeepBoth Strategy = "KEEP_BOTH"
+
+	// Replace soft-deletes the existing package (state -> DELETING, name
+	// prefixed with __DELETED__<nodeId>_) before inserting the new one,
+	// and records the provenance link via replaces_package_id /
+	// replaced_by_package_id. Folders (Collection type) cannot be replaced
+	// — the DB CHECK constraint enforces this.
+	Replace Strategy = "REPLACE"
+
+	// Fail returns an error listing the conflicting names without inserting
+	// anything. Lets the caller resolve the conflict out-of-band.
+	Fail Strategy = "FAIL"
+)

--- a/pkg/models/pgdb/packageTable.go
+++ b/pkg/models/pgdb/packageTable.go
@@ -10,19 +10,21 @@ import (
 
 // Package is a representation of a container on Pennsieve that contains one or more sourceFiles
 type Package struct {
-	Id           int64                         `json:"id"`
-	Name         string                        `json:"name"`
-	PackageType  packageType.Type              `json:"type"`
-	PackageState packageState.State            `json:"state"`
-	NodeId       string                        `json:"node_id"`
-	ParentId     sql.NullInt64                 `json:"parent_id"`
-	DatasetId    int                           `json:"dataset_id"`
-	OwnerId      int                           `json:"owner_id"`
-	Size         sql.NullInt64                 `json:"size"`
-	ImportId     sql.NullString                `json:"import_id"`
-	Attributes   packageInfo.PackageAttributes `json:"attributes"`
-	CreatedAt    time.Time                     `json:"created_at"`
-	UpdatedAt    time.Time                     `json:"updated_at"`
+	Id                  int64                         `json:"id"`
+	Name                string                        `json:"name"`
+	PackageType         packageType.Type              `json:"type"`
+	PackageState        packageState.State            `json:"state"`
+	NodeId              string                        `json:"node_id"`
+	ParentId            sql.NullInt64                 `json:"parent_id"`
+	DatasetId           int                           `json:"dataset_id"`
+	OwnerId             int                           `json:"owner_id"`
+	Size                sql.NullInt64                 `json:"size"`
+	ImportId            sql.NullString                `json:"import_id"`
+	Attributes          packageInfo.PackageAttributes `json:"attributes"`
+	CreatedAt           time.Time                     `json:"created_at"`
+	UpdatedAt           time.Time                     `json:"updated_at"`
+	ReplacesPackageId   sql.NullInt64                 `json:"replaces_package_id"`
+	ReplacedByPackageId sql.NullInt64                 `json:"replaced_by_package_id"`
 }
 
 // PackageParams is used as the input to create a package

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/lib/pq"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/conflictStrategy"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
@@ -86,12 +87,26 @@ func (q *Queries) AddFolder(ctx context.Context, r pgdb.PackageParams) (*pgdb.Pa
 
 }
 
-// AddPackages adds packages to a dataset.
+// AddPackages adds packages to a dataset with the legacy "keep both" conflict
+// behavior: name collisions result in the new package being renamed with a
+// " (N)" suffix until it lands. Equivalent to AddPackagesWithConflict using
+// conflictStrategy.KeepBoth.
 //   - This call should typically be wrapped in a Transaction as it will run multiple queries.
 //   - Packages can be in different folders, but it is assumed that the folders already exist.
 func (q *Queries) AddPackages(ctx context.Context, records []pgdb.PackageParams) ([]pgdb.Package, error) {
-	var allInsertedPackages []pgdb.Package
+	return q.AddPackagesWithConflict(ctx, records, conflictStrategy.KeepBoth)
+}
 
+// AddPackagesWithConflict adds packages, using the given strategy to resolve
+// name collisions with existing non-deleted packages under the same
+// (dataset_id, parent_id, name) tuple.
+//   - This call should typically be wrapped in a Transaction as it will run multiple queries.
+//   - Collection-type records are rejected; use AddFolder instead.
+//   - Replace soft-deletes the conflicting predecessor (state=DELETING, name
+//     prefixed with __DELETED__<nodeId>_) and links the new package via
+//     replaces_package_id / replaced_by_package_id.
+//   - Fail returns an error listing conflicting names without inserting anything.
+func (q *Queries) AddPackagesWithConflict(ctx context.Context, records []pgdb.PackageParams, strategy conflictStrategy.Strategy) ([]pgdb.Package, error) {
 	for _, r := range records {
 		if r.PackageType == packageType.Collection {
 			return nil, errors.New("cannot create COLLECTION package with AddPackages method, use AddFolder instead")
@@ -104,41 +119,190 @@ func (q *Queries) AddPackages(ctx context.Context, records []pgdb.PackageParams)
 		parentIdMap[r.ParentId] = append(parentIdMap[r.ParentId], r)
 	}
 
+	var allInsertedPackages []pgdb.Package
 	for parentId, pRecords := range parentIdMap {
-		insertedPackages, failedPackages, err := q.addPackageByParent(ctx, parentId, pRecords)
+		var inserted []pgdb.Package
+		var err error
+		switch strategy {
+		case conflictStrategy.KeepBoth:
+			inserted, err = q.addPackagesKeepBoth(ctx, parentId, pRecords)
+		case conflictStrategy.Replace:
+			inserted, err = q.addPackagesReplace(ctx, parentId, pRecords)
+		case conflictStrategy.Fail:
+			inserted, err = q.addPackagesFail(ctx, parentId, pRecords)
+		default:
+			return nil, fmt.Errorf("unknown conflict strategy: %s", strategy)
+		}
+		if err != nil {
+			return nil, err
+		}
+		allInsertedPackages = append(allInsertedPackages, inserted...)
+	}
+	return allInsertedPackages, nil
+}
+
+// addPackagesKeepBoth retries with " (N)"-suffixed names until all records
+// are inserted.
+func (q *Queries) addPackagesKeepBoth(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, error) {
+	var allInsertedPackages []pgdb.Package
+
+	insertedPackages, failedPackages, err := q.addPackageByParent(ctx, parentId, records, nil)
+	if err != nil {
+		return nil, err
+	}
+	allInsertedPackages = append(allInsertedPackages, insertedPackages...)
+
+	failedNameMap := map[string]string{}
+	for _, p := range failedPackages {
+		failedNameMap[p.Name] = p.Name
+	}
+
+	index := 1
+	for len(failedPackages) > 0 {
+		for i := range failedPackages {
+			originalName := failedNameMap[failedPackages[i].Name]
+			expandName(&failedPackages[i], originalName, index)
+			failedNameMap[failedPackages[i].Name] = originalName
+		}
+
+		insertedPackages, failedPackages, err = q.addPackageByParent(ctx, parentId, failedPackages, nil)
 		if err != nil {
 			return nil, err
 		}
 
 		allInsertedPackages = append(allInsertedPackages, insertedPackages...)
 
-		// Update name of failed packages and re-insert.
-		failedNameMap := map[string]string{}
-		for _, p := range failedPackages {
-			failedNameMap[p.Name] = p.Name
-		}
-
-		index := 1
-		for len(failedPackages) > 0 {
-			for i := range failedPackages {
-
-				originalName := failedNameMap[failedPackages[i].Name]
-				expandName(&failedPackages[i], originalName, index)
-				failedNameMap[failedPackages[i].Name] = originalName
-			}
-
-			insertedPackages, failedPackages, err = q.addPackageByParent(ctx, parentId, failedPackages)
-			if err != nil {
-				return nil, err
-			}
-
-			allInsertedPackages = append(allInsertedPackages, insertedPackages...)
-
-			index++
-		}
+		index++
 	}
 	return allInsertedPackages, nil
+}
 
+// addPackagesReplace soft-deletes each conflicting predecessor, inserts the
+// new packages with replaces_package_id set, then writes the back-reference.
+// Caller must ensure the call runs in a transaction for atomicity.
+func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, error) {
+	conflicts, err := q.findConflictingPackages(ctx, parentId, records)
+	if err != nil {
+		return nil, err
+	}
+
+	replacementByNodeId := map[string]int64{}
+	for _, r := range records {
+		if old, ok := conflicts[r.Name]; ok {
+			replacementByNodeId[r.NodeId] = old.Id
+		}
+	}
+
+	// Rename + soft-delete each predecessor so the new insert doesn't trip
+	// the unique (name, dataset_id, parent_id) partial indexes.
+	for _, old := range conflicts {
+		newName := fmt.Sprintf("__DELETED__%s_%s", old.NodeId, old.Name)
+		_, err := q.db.ExecContext(ctx,
+			"UPDATE packages SET state=$1, name=$2 WHERE id=$3",
+			packageState.Deleting.String(), newName, old.Id)
+		if err != nil {
+			return nil, fmt.Errorf("soft-deleting predecessor %d: %w", old.Id, err)
+		}
+	}
+
+	inserted, failed, err := q.addPackageByParent(ctx, parentId, records, replacementByNodeId)
+	if err != nil {
+		return nil, err
+	}
+	if len(failed) > 0 {
+		return nil, fmt.Errorf("replace: %d unexpected insert failures after predecessor rename", len(failed))
+	}
+
+	// Link back: old.replaced_by_package_id = new.id
+	for _, p := range inserted {
+		if !p.ReplacesPackageId.Valid {
+			continue
+		}
+		_, err := q.db.ExecContext(ctx,
+			"UPDATE packages SET replaced_by_package_id=$1 WHERE id=$2",
+			p.Id, p.ReplacesPackageId.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("setting back-ref on predecessor %d: %w", p.ReplacesPackageId.Int64, err)
+		}
+	}
+
+	return inserted, nil
+}
+
+// addPackagesFail returns an error if any record name collides with an
+// existing non-deleted package under the same parent; otherwise inserts
+// straight through without the rename-retry loop.
+func (q *Queries) addPackagesFail(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, error) {
+	conflicts, err := q.findConflictingPackages(ctx, parentId, records)
+	if err != nil {
+		return nil, err
+	}
+	if len(conflicts) > 0 {
+		names := make([]string, 0, len(conflicts))
+		for n := range conflicts {
+			names = append(names, n)
+		}
+		return nil, fmt.Errorf("conflict strategy FAIL: %d conflicting name(s): %v", len(names), names)
+	}
+
+	inserted, failed, err := q.addPackageByParent(ctx, parentId, records, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(failed) > 0 {
+		// Post-check failed (race with another insert). Surface the names.
+		failedNames := make([]string, 0, len(failed))
+		for _, f := range failed {
+			failedNames = append(failedNames, f.Name)
+		}
+		return nil, fmt.Errorf("conflict strategy FAIL: %d insert failure(s) after conflict check: %v", len(failed), failedNames)
+	}
+	return inserted, nil
+}
+
+// findConflictingPackages returns existing, non-deleted packages under the
+// given parent whose name matches any of the incoming records.
+func (q *Queries) findConflictingPackages(ctx context.Context, parentId int64, records []pgdb.PackageParams) (map[string]*pgdb.Package, error) {
+	if len(records) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(records))
+	for _, r := range records {
+		names = append(names, r.Name)
+	}
+	datasetId := records[0].DatasetId
+
+	var queryStr string
+	var args []interface{}
+	if parentId < 0 {
+		queryStr = "SELECT id, name, node_id FROM packages " +
+			"WHERE dataset_id=$1 AND parent_id IS NULL " +
+			"AND state NOT IN ($2, $3) AND name = ANY($4)"
+		args = []interface{}{datasetId, packageState.Deleting.String(), packageState.Deleted.String(), pq.Array(names)}
+	} else {
+		queryStr = "SELECT id, name, node_id FROM packages " +
+			"WHERE dataset_id=$1 AND parent_id=$2 " +
+			"AND state NOT IN ($3, $4) AND name = ANY($5)"
+		args = []interface{}{datasetId, parentId, packageState.Deleting.String(), packageState.Deleted.String(), pq.Array(names)}
+	}
+
+	rows, err := q.db.QueryContext(ctx, queryStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	conflicts := map[string]*pgdb.Package{}
+	for rows.Next() {
+		var p pgdb.Package
+		if err := rows.Scan(&p.Id, &p.Name, &p.NodeId); err != nil {
+			return nil, err
+		}
+		pkg := p
+		conflicts[pkg.Name] = &pkg
+	}
+	return conflicts, nil
 }
 
 // GetPackageChildren Get the children in a package
@@ -271,13 +435,18 @@ func (q *Queries) GetPackageAncestorIds(ctx context.Context, packageId int64) ([
 }
 
 // PRIVATE
-// AddPackages runs the query to insert a set of packages that belong to the same parent folder.
-//   - If adding packages to root-folder, the parentId should be set to -1
+// addPackageByParent runs the query to insert a set of packages that belong
+// to the same parent folder.
+//   - If adding packages to root-folder, the parentId should be set to -1.
+//   - replacementByNodeId, if non-nil, maps each incoming record's NodeId to
+//     the id of the existing package it replaces. The caller is responsible
+//     for soft-deleting the predecessor before this call to avoid tripping
+//     the (name, dataset_id, parent_id) unique indexes.
 //
 // It returns two arrays:
 //  1. successfully created packages,
 //  2. packages that failed to be inserted due to a name constraint.
-func (q *Queries) addPackageByParent(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, []pgdb.PackageParams, error) {
+func (q *Queries) addPackageByParent(ctx context.Context, parentId int64, records []pgdb.PackageParams, replacementByNodeId map[string]int64) ([]pgdb.Package, []pgdb.PackageParams, error) {
 
 	log.Debug(fmt.Sprintf("ADD PACKAGES: %v", records))
 
@@ -316,30 +485,29 @@ func (q *Queries) addPackageByParent(ctx context.Context, parentId int64, record
 	}
 
 	sqlInsert := "INSERT INTO packages(name, type, state, node_id, parent_id, " +
-		"dataset_id, owner_id, size, import_id, attributes, created_at, updated_at) VALUES "
+		"dataset_id, owner_id, size, import_id, attributes, created_at, updated_at, replaces_package_id) VALUES "
 
+	const columnsPerRow = 13
 	for index, row := range validRecords {
-		inserts = append(inserts, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d,$%d)",
-			index*12+1,
-			index*12+2,
-			index*12+3,
-			index*12+4,
-			index*12+5,
-			index*12+6,
-			index*12+7,
-			index*12+8,
-			index*12+9,
-			index*12+10,
-			index*12+11,
-			index*12+12,
-		))
+		placeholders := make([]string, columnsPerRow)
+		for c := 0; c < columnsPerRow; c++ {
+			placeholders[c] = fmt.Sprintf("$%d", index*columnsPerRow+c+1)
+		}
+		inserts = append(inserts, "("+strings.Join(placeholders, ",")+")")
+
+		var replacesId sql.NullInt64
+		if replacementByNodeId != nil {
+			if oldId, ok := replacementByNodeId[row.NodeId]; ok {
+				replacesId = sql.NullInt64{Int64: oldId, Valid: true}
+			}
+		}
 
 		values = append(values, row.Name, row.PackageType.String(), row.PackageState.String(), row.NodeId, sqlParentId, row.DatasetId,
-			row.OwnerId, row.Size, row.ImportId, row.Attributes, currentTime, currentTime)
+			row.OwnerId, row.Size, row.ImportId, row.Attributes, currentTime, currentTime, replacesId)
 	}
 
 	returnRows := "id, name, type, state, node_id, parent_id, " +
-		"dataset_id, owner_id, size, import_id, created_at, updated_at"
+		"dataset_id, owner_id, size, import_id, created_at, updated_at, replaces_package_id, replaced_by_package_id"
 
 	// Returning packages. If we run into a constraint, return the existing package.
 	// We will check in the addPackages function for the ID to see if there was a conflict.
@@ -383,6 +551,8 @@ func (q *Queries) addPackageByParent(ctx context.Context, parentId int64, record
 			&currentRecord.ImportId,
 			&currentRecord.CreatedAt,
 			&currentRecord.UpdatedAt,
+			&currentRecord.ReplacesPackageId,
+			&currentRecord.ReplacedByPackageId,
 		)
 
 		if err != nil {

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -177,8 +177,11 @@ func (q *Queries) addPackagesKeepBoth(ctx context.Context, parentId int64, recor
 	return allInsertedPackages, nil
 }
 
-// addPackagesReplace soft-deletes each conflicting predecessor, inserts the
-// new packages with replaces_package_id set, then writes the back-reference.
+// addPackagesReplace soft-deletes each conflicting predecessor, decrements
+// its storage counts, inserts the new packages with replaces_package_id set,
+// then writes the back-reference. Async S3 asset cleanup is the caller's
+// responsibility (publish a DeletePackageJob to the jobs queue for each
+// returned package with ReplacesPackageId set).
 // Caller must ensure the call runs in a transaction for atomicity.
 func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, error) {
 	conflicts, err := q.findConflictingPackages(ctx, parentId, records)
@@ -193,8 +196,12 @@ func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, record
 		}
 	}
 
+	datasetId := int64(records[0].DatasetId)
+
 	// Rename + soft-delete each predecessor so the new insert doesn't trip
-	// the unique (name, dataset_id, parent_id) partial indexes.
+	// the unique (name, dataset_id, parent_id) partial indexes, and decrement
+	// its storage so dataset/ancestor counts reflect the removal. Mirrors
+	// pennsieve-api's PackageManager.delete behavior on the DB side.
 	for _, old := range conflicts {
 		newName := fmt.Sprintf("__DELETED__%s_%s", old.NodeId, old.Name)
 		_, err := q.db.ExecContext(ctx,
@@ -202,6 +209,24 @@ func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, record
 			packageState.Deleting.String(), newName, old.Id)
 		if err != nil {
 			return nil, fmt.Errorf("soft-deleting predecessor %d: %w", old.Id, err)
+		}
+
+		size, err := q.GetPackageStorageById(ctx, old.Id)
+		if err != nil {
+			// No storage row just means no decrement needed.
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return nil, fmt.Errorf("reading storage for predecessor %d: %w", old.Id, err)
+		}
+		if size <= 0 {
+			continue
+		}
+		if err := q.IncrementPackageStorageAncestors(ctx, old.Id, -size); err != nil {
+			return nil, fmt.Errorf("decrementing package/ancestor storage for predecessor %d: %w", old.Id, err)
+		}
+		if err := q.IncrementDatasetStorage(ctx, datasetId, -size); err != nil {
+			return nil, fmt.Errorf("decrementing dataset storage for predecessor %d: %w", old.Id, err)
 		}
 	}
 

--- a/pkg/queries/pgdb/packages_test.go
+++ b/pkg/queries/pgdb/packages_test.go
@@ -618,23 +618,34 @@ func testGettingAncestors(t *testing.T, store *SQLStore, orgId int) {
 
 // testConflictReplace verifies the Replace strategy soft-deletes the
 // predecessor, inserts the new package with the back-reference populated,
-// and sets replaced_by_package_id on the predecessor.
+// sets replaced_by_package_id on the predecessor, and decrements the
+// predecessor's storage counts (package + dataset) to match
+// pennsieve-api's PackageManager.delete behavior.
 func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
 	defer test.Truncate(t, store.db, orgId, "packages")
+	defer test.Truncate(t, store.db, orgId, "package_storage")
+	defer test.Truncate(t, store.db, orgId, "dataset_storage")
+
+	datasetId := int64(1)
 
 	// Seed: a single package at root.
 	original := test.GenerateTestPackages([]test.PackageParams{
 		{Name: "report.csv", ParentId: -1},
-	}, 1)
+	}, int(datasetId))
 	originalResult, err := store.AddPackagesWithConflict(context.Background(), original, conflictStrategy.KeepBoth)
 	assert.NoError(t, err)
 	assert.Len(t, originalResult, 1)
 	originalId := originalResult[0].Id
 
+	// Seed storage rows so we can verify decrement.
+	const predecessorSize = int64(1000)
+	assert.NoError(t, store.Queries.IncrementPackageStorage(context.Background(), originalId, predecessorSize))
+	assert.NoError(t, store.Queries.IncrementDatasetStorage(context.Background(), datasetId, predecessorSize))
+
 	// Replace: upload a new package with the same name.
 	replacement := test.GenerateTestPackages([]test.PackageParams{
 		{Name: "report.csv", ParentId: -1},
-	}, 1)
+	}, int(datasetId))
 	replacementResult, err := store.AddPackagesWithConflict(context.Background(), replacement, conflictStrategy.Replace)
 	assert.NoError(t, err)
 	assert.Len(t, replacementResult, 1)
@@ -657,6 +668,15 @@ func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
 	assert.Contains(t, predecessorName, "__DELETED__", "Predecessor should be renamed with __DELETED__ prefix")
 	assert.True(t, predecessorReplacedBy.Valid, "replaced_by_package_id should be set")
 	assert.Equal(t, newPkg.Id, predecessorReplacedBy.Int64, "Predecessor's replaced_by_package_id should point at the new row")
+
+	// Storage counts on the predecessor and dataset should be decremented to 0.
+	predecessorStorage, err := store.Queries.GetPackageStorageById(context.Background(), originalId)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), predecessorStorage, "Predecessor package_storage should decrement to 0")
+
+	datasetStorage, err := store.Queries.GetDatasetStorageById(context.Background(), datasetId)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), datasetStorage, "Dataset storage should decrement to 0")
 }
 
 // testConflictFail verifies the Fail strategy rejects conflicting inserts

--- a/pkg/queries/pgdb/packages_test.go
+++ b/pkg/queries/pgdb/packages_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/conflictStrategy"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageState"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/packageInfo/packageType"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/pgdb"
@@ -26,6 +27,9 @@ func TestPackageTable(t *testing.T) {
 		"Test adding nested packages":    testAddingNestedPackages,
 		"Test name expansion":            testNameExpansion,
 		"Test getting ancestor Ids":      testGettingAncestors,
+		"Test conflict replace":          testConflictReplace,
+		"Test conflict fail":             testConflictFail,
+		"Test conflict replace no-op":    testConflictReplaceNoConflict,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 1
@@ -270,7 +274,7 @@ func testAddingPackagesToRoot(t *testing.T, store *SQLStore, orgId int) {
 	}
 
 	insertParams := test.GenerateTestPackages(testParams, 1)
-	results, failedPackages, err := store.Queries.addPackageByParent(context.Background(), -1, insertParams)
+	results, failedPackages, err := store.Queries.addPackageByParent(context.Background(), -1, insertParams, nil)
 	assert.Empty(t, failedPackages, "All packages should be inserted correctly.")
 	assert.NoError(t, err)
 	assert.Len(t, results, 5, "Expect to return 5 packages")
@@ -280,7 +284,7 @@ func testAddingPackagesToRoot(t *testing.T, store *SQLStore, orgId int) {
 		{Name: "package_1.txt", ParentId: -1}}
 
 	insertParams = test.GenerateTestPackages(testParams, 1)
-	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams)
+	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams, nil)
 	assert.NoError(t, err)
 	assert.Len(t, results, 0, "Expect to not insert package as there is a conflict.")
 	assert.Len(t, failedPackages, 1)
@@ -288,7 +292,7 @@ func testAddingPackagesToRoot(t *testing.T, store *SQLStore, orgId int) {
 
 	// Test inserting package with same name to different dataset
 	insertParams = test.GenerateTestPackages(testParams, 2)
-	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams)
+	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams, nil)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1, "Expect to insert package in dataset 2.")
 	assert.Len(t, failedPackages, 0)
@@ -344,7 +348,7 @@ func testAddingNestedPackages(t *testing.T, store *SQLStore, orgId int) {
 	}
 
 	insertParams := test.GenerateTestPackages(testParams, 1)
-	results, failedPackages, err := store.Queries.addPackageByParent(context.Background(), result.Id, insertParams)
+	results, failedPackages, err := store.Queries.addPackageByParent(context.Background(), result.Id, insertParams, nil)
 	assert.Empty(t, failedPackages, "All packages should be inserted correctly.")
 	assert.NoError(t, err)
 	assert.Len(t, results, 5, "Expect to return 5 packages")
@@ -354,7 +358,7 @@ func testAddingNestedPackages(t *testing.T, store *SQLStore, orgId int) {
 		{Name: "package_6.txt", ParentId: result.Id},
 	}
 	insertParams = test.GenerateTestPackages(testParams, 1)
-	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams)
+	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams, nil)
 	assert.Error(t, err, "Should return an error when parent_id in call does not match parent_id in params.")
 	assert.Nil(t, results)
 	assert.Nil(t, failedPackages)
@@ -365,7 +369,7 @@ func testAddingNestedPackages(t *testing.T, store *SQLStore, orgId int) {
 		{Name: "package_2.txt", ParentId: -1},
 	}
 	insertParams = test.GenerateTestPackages(testParams, 1)
-	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), result.Id, insertParams)
+	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), result.Id, insertParams, nil)
 	assert.Error(t, err, "Should return an error when parent_id in call does not match parent_id in params.")
 	assert.Nil(t, results)
 	assert.Nil(t, failedPackages)
@@ -375,7 +379,7 @@ func testAddingNestedPackages(t *testing.T, store *SQLStore, orgId int) {
 		{Name: "package_1.txt", ParentId: result.Id},
 	}
 	insertParams = test.GenerateTestPackages(testParams, 1)
-	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), result.Id, insertParams)
+	results, failedPackages, err = store.Queries.addPackageByParent(context.Background(), result.Id, insertParams, nil)
 	assert.NoError(t, err)
 	assert.Len(t, results, 0, "Expect to not insert package as there is a naming conflict.")
 	assert.Len(t, failedPackages, 1, "Expect package to fail.")
@@ -587,7 +591,7 @@ func testGettingAncestors(t *testing.T, store *SQLStore, orgId int) {
 		{Name: "package_1.txt", ParentId: folder2.Id},
 	}
 	insertParams := test.GenerateTestPackages(testParams, 1)
-	results, _, err := store.Queries.addPackageByParent(context.Background(), folder2.Id, insertParams)
+	results, _, err := store.Queries.addPackageByParent(context.Background(), folder2.Id, insertParams, nil)
 	assert.NoError(t, err)
 
 	ancestorIds, err := store.Queries.GetPackageAncestorIds(context.Background(), results[0].Id)
@@ -602,7 +606,7 @@ func testGettingAncestors(t *testing.T, store *SQLStore, orgId int) {
 		{Name: "package_root.txt", ParentId: -1},
 	}
 	insertParams = test.GenerateTestPackages(testParams, 1)
-	results, _, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams)
+	results, _, err = store.Queries.addPackageByParent(context.Background(), -1, insertParams, nil)
 	assert.NoError(t, err)
 
 	ancestorIds, err = store.Queries.GetPackageAncestorIds(context.Background(), results[0].Id)
@@ -610,4 +614,101 @@ func testGettingAncestors(t *testing.T, store *SQLStore, orgId int) {
 	assert.Len(t, ancestorIds, 1)
 	assert.Equal(t, ancestorIds[0], results[0].Id, "Expecting first value to be the current package id")
 
+}
+
+// testConflictReplace verifies the Replace strategy soft-deletes the
+// predecessor, inserts the new package with the back-reference populated,
+// and sets replaced_by_package_id on the predecessor.
+func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
+	defer test.Truncate(t, store.db, orgId, "packages")
+
+	// Seed: a single package at root.
+	original := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "report.csv", ParentId: -1},
+	}, 1)
+	originalResult, err := store.AddPackagesWithConflict(context.Background(), original, conflictStrategy.KeepBoth)
+	assert.NoError(t, err)
+	assert.Len(t, originalResult, 1)
+	originalId := originalResult[0].Id
+
+	// Replace: upload a new package with the same name.
+	replacement := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "report.csv", ParentId: -1},
+	}, 1)
+	replacementResult, err := store.AddPackagesWithConflict(context.Background(), replacement, conflictStrategy.Replace)
+	assert.NoError(t, err)
+	assert.Len(t, replacementResult, 1)
+
+	newPkg := replacementResult[0]
+	assert.Equal(t, "report.csv", newPkg.Name, "New package keeps the original requested name")
+	assert.NotEqual(t, originalId, newPkg.Id, "Replacement should be a new row")
+	assert.True(t, newPkg.ReplacesPackageId.Valid, "replaces_package_id should be set")
+	assert.Equal(t, originalId, newPkg.ReplacesPackageId.Int64, "replaces_package_id should point at the predecessor")
+
+	// Predecessor should be state=DELETING, name prefixed, and back-referenced.
+	selectStmt := fmt.Sprintf(
+		"SELECT name, state, replaced_by_package_id FROM \"%d\".packages WHERE id=$1",
+		orgId)
+	var predecessorName, predecessorState string
+	var predecessorReplacedBy sql.NullInt64
+	err = store.db.QueryRow(selectStmt, originalId).Scan(&predecessorName, &predecessorState, &predecessorReplacedBy)
+	assert.NoError(t, err)
+	assert.Equal(t, packageState.Deleting.String(), predecessorState, "Predecessor should be in DELETING state")
+	assert.Contains(t, predecessorName, "__DELETED__", "Predecessor should be renamed with __DELETED__ prefix")
+	assert.True(t, predecessorReplacedBy.Valid, "replaced_by_package_id should be set")
+	assert.Equal(t, newPkg.Id, predecessorReplacedBy.Int64, "Predecessor's replaced_by_package_id should point at the new row")
+}
+
+// testConflictFail verifies the Fail strategy rejects conflicting inserts
+// without touching the database, and inserts cleanly when no conflict exists.
+func testConflictFail(t *testing.T, store *SQLStore, orgId int) {
+	defer test.Truncate(t, store.db, orgId, "packages")
+
+	// Seed: package at root.
+	seed := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "data.bin", ParentId: -1},
+	}, 1)
+	_, err := store.AddPackagesWithConflict(context.Background(), seed, conflictStrategy.KeepBoth)
+	assert.NoError(t, err)
+
+	// Fail strategy with a conflict should error and insert nothing.
+	conflict := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "data.bin", ParentId: -1},
+		{Name: "fresh.bin", ParentId: -1},
+	}, 1)
+	result, err := store.AddPackagesWithConflict(context.Background(), conflict, conflictStrategy.Fail)
+	assert.Error(t, err, "Fail strategy should error on conflict")
+	assert.Nil(t, result, "No packages should be returned on conflict")
+
+	// Confirm fresh.bin was NOT inserted (atomicity — all-or-nothing).
+	var count int
+	countStmt := fmt.Sprintf("SELECT COUNT(*) FROM \"%d\".packages WHERE name='fresh.bin'", orgId)
+	assert.NoError(t, store.db.QueryRow(countStmt).Scan(&count))
+	assert.Equal(t, 0, count, "No non-conflicting records should be inserted when Fail aborts")
+
+	// Fail strategy with no conflict should succeed.
+	clean := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "brand_new.bin", ParentId: -1},
+	}, 1)
+	result, err = store.AddPackagesWithConflict(context.Background(), clean, conflictStrategy.Fail)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "brand_new.bin", result[0].Name)
+	assert.False(t, result[0].ReplacesPackageId.Valid, "Non-replace insert should have null replaces_package_id")
+}
+
+// testConflictReplaceNoConflict verifies the Replace strategy inserts
+// cleanly (no predecessor rename, no back-reference) when no conflict exists.
+func testConflictReplaceNoConflict(t *testing.T, store *SQLStore, orgId int) {
+	defer test.Truncate(t, store.db, orgId, "packages")
+
+	fresh := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "solo.txt", ParentId: -1},
+	}, 1)
+	result, err := store.AddPackagesWithConflict(context.Background(), fresh, conflictStrategy.Replace)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "solo.txt", result[0].Name)
+	assert.False(t, result[0].ReplacesPackageId.Valid, "No conflict = no replaces_package_id")
+	assert.False(t, result[0].ReplacedByPackageId.Valid, "Fresh insert should have null replaced_by_package_id")
 }


### PR DESCRIPTION
## Summary
- New `AddPackagesWithConflict(ctx, records, strategy)` with `KeepBoth` | `Replace` | `Fail` strategies
- Existing `AddPackages` signature preserved — internally delegates with `KeepBoth`, so no behavior change for current callers
- `Replace` soft-deletes predecessor in-tx (state=DELETING, `__DELETED__<nodeId>_` prefix), inserts new with `replaces_package_id`, closes back-ref on predecessor
- `Fail` returns an error listing conflicts without inserting
- `pgdb.Package` gains `ReplacesPackageId` and `ReplacedByPackageId` (`sql.NullInt64`) so callers can see the provenance link
- Test DB image bumped to `V20260419000000-seed` for the new columns (requires pennsieve-api PR #376)

## Callers
Only production caller of `AddPackages` today is `upload-service-v2/lambda/upload/handler/store.go:193`. It stays on the `KeepBoth` default (via the preserved `AddPackages` entry point) until a follow-up PR threads the upload manifest's `onConflict` intent through to `AddPackagesWithConflict`.

## Test plan
- [x] Existing tests still pass (`Test_adding_folders`, `Test_adding_packages_to_root`, `Test_adding_nested_packages`, etc.)
- [x] New `Test_conflict_replace` verifies predecessor rename to `__DELETED__`, state=DELETING, and both-direction back-references
- [x] New `Test_conflict_fail` verifies atomic abort on conflict and clean insert when no conflict
- [x] New `Test_conflict_replace_no-op` verifies Replace is a pass-through when no conflict exists
- [ ] Release tag cut after merge; upload-service-v2 follow-up bumps the dependency

## Dependencies
- Requires pennsieve-api PR #376 (schema migration) to be merged before this releases, since the tests here depend on the `V20260419000000-seed` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)