### PR TITLE
Remove Fail conflict strategy

### DIFF
--- a/pkg/models/packageInfo/conflictStrategy/models.go
+++ b/pkg/models/packageInfo/conflictStrategy/models.go
@@ -16,8 +16,4 @@ const (
 	// replaced_by_package_id. Folders (Collection type) cannot be replaced
 	// — the DB CHECK constraint enforces this.
 	Replace Strategy = "REPLACE"
-
-	// Fail returns an error listing the conflicting names without inserting
-	// anything. Lets the caller resolve the conflict out-of-band.
-	Fail Strategy = "FAIL"
 )

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -128,8 +128,6 @@ func (q *Queries) AddPackagesWithConflict(ctx context.Context, records []pgdb.Pa
 			inserted, err = q.addPackagesKeepBoth(ctx, parentId, pRecords)
 		case conflictStrategy.Replace:
 			inserted, err = q.addPackagesReplace(ctx, parentId, pRecords)
-		case conflictStrategy.Fail:
-			inserted, err = q.addPackagesFail(ctx, parentId, pRecords)
 		default:
 			return nil, fmt.Errorf("unknown conflict strategy: %s", strategy)
 		}
@@ -251,37 +249,6 @@ func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, record
 		}
 	}
 
-	return inserted, nil
-}
-
-// addPackagesFail returns an error if any record name collides with an
-// existing non-deleted package under the same parent; otherwise inserts
-// straight through without the rename-retry loop.
-func (q *Queries) addPackagesFail(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, error) {
-	conflicts, err := q.findConflictingPackages(ctx, parentId, records)
-	if err != nil {
-		return nil, err
-	}
-	if len(conflicts) > 0 {
-		names := make([]string, 0, len(conflicts))
-		for n := range conflicts {
-			names = append(names, n)
-		}
-		return nil, fmt.Errorf("conflict strategy FAIL: %d conflicting name(s): %v", len(names), names)
-	}
-
-	inserted, failed, err := q.addPackageByParent(ctx, parentId, records, nil)
-	if err != nil {
-		return nil, err
-	}
-	if len(failed) > 0 {
-		// Post-check failed (race with another insert). Surface the names.
-		failedNames := make([]string, 0, len(failed))
-		for _, f := range failed {
-			failedNames = append(failedNames, f.Name)
-		}
-		return nil, fmt.Errorf("conflict strategy FAIL: %d insert failure(s) after conflict check: %v", len(failed), failedNames)
-	}
 	return inserted, nil
 }
 

--- a/pkg/queries/pgdb/packages_test.go
+++ b/pkg/queries/pgdb/packages_test.go
@@ -28,7 +28,6 @@ func TestPackageTable(t *testing.T) {
 		"Test name expansion":            testNameExpansion,
 		"Test getting ancestor Ids":      testGettingAncestors,
 		"Test conflict replace":          testConflictReplace,
-		"Test conflict fail":             testConflictFail,
 		"Test conflict replace no-op":    testConflictReplaceNoConflict,
 	} {
 		t.Run(scenario, func(t *testing.T) {
@@ -677,44 +676,6 @@ func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
 	datasetStorage, err := store.Queries.GetDatasetStorageById(context.Background(), datasetId)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), datasetStorage, "Dataset storage should decrement to 0")
-}
-
-// testConflictFail verifies the Fail strategy rejects conflicting inserts
-// without touching the database, and inserts cleanly when no conflict exists.
-func testConflictFail(t *testing.T, store *SQLStore, orgId int) {
-	defer test.Truncate(t, store.db, orgId, "packages")
-
-	// Seed: package at root.
-	seed := test.GenerateTestPackages([]test.PackageParams{
-		{Name: "data.bin", ParentId: -1},
-	}, 1)
-	_, err := store.AddPackagesWithConflict(context.Background(), seed, conflictStrategy.KeepBoth)
-	assert.NoError(t, err)
-
-	// Fail strategy with a conflict should error and insert nothing.
-	conflict := test.GenerateTestPackages([]test.PackageParams{
-		{Name: "data.bin", ParentId: -1},
-		{Name: "fresh.bin", ParentId: -1},
-	}, 1)
-	result, err := store.AddPackagesWithConflict(context.Background(), conflict, conflictStrategy.Fail)
-	assert.Error(t, err, "Fail strategy should error on conflict")
-	assert.Nil(t, result, "No packages should be returned on conflict")
-
-	// Confirm fresh.bin was NOT inserted (atomicity — all-or-nothing).
-	var count int
-	countStmt := fmt.Sprintf("SELECT COUNT(*) FROM \"%d\".packages WHERE name='fresh.bin'", orgId)
-	assert.NoError(t, store.db.QueryRow(countStmt).Scan(&count))
-	assert.Equal(t, 0, count, "No non-conflicting records should be inserted when Fail aborts")
-
-	// Fail strategy with no conflict should succeed.
-	clean := test.GenerateTestPackages([]test.PackageParams{
-		{Name: "brand_new.bin", ParentId: -1},
-	}, 1)
-	result, err = store.AddPackagesWithConflict(context.Background(), clean, conflictStrategy.Fail)
-	assert.NoError(t, err)
-	assert.Len(t, result, 1)
-	assert.Equal(t, "brand_new.bin", result[0].Name)
-	assert.False(t, result[0].ReplacesPackageId.Valid, "Non-replace insert should have null replaces_package_id")
 }
 
 // testConflictReplaceNoConflict verifies the Replace strategy inserts


### PR DESCRIPTION
Removes conflictStrategy.Fail + addPackagesFail(). Batch-abort semantic was user-hostile at upload scale. Binary UX (keepBoth/replace) is the new direction; skip, if needed, is cleanest as a client-side pre-filter via datasets-service manifest endpoint. Cuts v1.17.0 on merge.