### PR TITLE
Add package-delete library and move storage cleanup out of replace

### DIFF
--- a/pkg/packagedelete/delete.go
+++ b/pkg/packagedelete/delete.go
@@ -1,0 +1,91 @@
+package packagedelete
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// QueueSender sends one message to the delete queue. Caller supplies
+// the implementation for loading messages on the queue.
+// DeletePackages calls SendToQueue once per request.
+type QueueSender interface {
+	SendToQueue(ctx context.Context, body []byte) error
+}
+
+// DeleteRequest is a single package to delete.
+//
+// UserNodeID is the user's node id, e.g. "N:user:abc". (The wire field
+// is named "userId" to match pennsieve-api — both sides carry a node id
+// here.)
+//
+// TraceID is any string that helps trace this job in the consumer's
+// logs. The upload service uses the manifest id; an API call would use
+// its request trace id. Required.
+type DeleteRequest struct {
+	PackageID      int64  `json:"packageId"`
+	OrganizationID int64  `json:"organizationId"`
+	UserNodeID     string `json:"userId"`
+	TraceID        string `json:"traceId"`
+}
+
+// DeletePackages sends one delete message per request through the given
+// QueueSender. If a single request fails (bad input, marshal error, send
+// error), the others still go through — the first error is returned so
+// you know something went wrong without losing the good ones.
+func DeletePackages(ctx context.Context, sender QueueSender, reqs []DeleteRequest) error {
+	if sender == nil {
+		return errors.New("packagedelete: QueueSender is nil")
+	}
+	if len(reqs) == 0 {
+		return nil
+	}
+
+	var firstErr error
+	recordErr := func(i int, err error) {
+		if firstErr == nil {
+			firstErr = fmt.Errorf("request %d: %w", i, err)
+		}
+	}
+
+	for i, r := range reqs {
+		if err := validate(r); err != nil {
+			recordErr(i, err)
+			continue
+		}
+		body, err := json.Marshal(map[string]any{
+			"DeletePackageJob": struct {
+				DeleteRequest
+				Id string `json:"id"`
+			}{r, uuid.NewString()},
+		})
+		if err != nil {
+			recordErr(i, fmt.Errorf("marshal: %w", err))
+			continue
+		}
+		if err := sender.SendToQueue(ctx, body); err != nil {
+			recordErr(i, fmt.Errorf("send: %w", err))
+			continue
+		}
+	}
+	return firstErr
+}
+
+func validate(r DeleteRequest) error {
+	if r.PackageID <= 0 {
+		return errors.New("PackageID must be > 0")
+	}
+	if r.OrganizationID <= 0 {
+		return errors.New("OrganizationID must be > 0")
+	}
+	if r.UserNodeID == "" {
+		return errors.New("UserNodeID is required")
+	}
+	if r.TraceID == "" {
+		return errors.New("TraceID is required")
+	}
+	return nil
+}

--- a/pkg/packagedelete/delete_test.go
+++ b/pkg/packagedelete/delete_test.go
@@ -1,0 +1,206 @@
+package packagedelete
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wireMessage decodes the JSON DeletePackages produces — used by tests
+// that need to read fields back out of a sent message. Mirrors the
+// shape: DeleteRequest's fields plus the per-message Id.
+type wireMessage struct {
+	DeleteRequest
+	Id string `json:"id"`
+}
+
+// fakeQueueSender records every message it's asked to send. Set failAt
+// to a call index (0-based) to make that one call return an error.
+type fakeQueueSender struct {
+	bodies   [][]byte
+	failAt   int  // -1 = never fail
+	gotCalls int
+}
+
+func newFakeQueueSender() *fakeQueueSender {
+	return &fakeQueueSender{failAt: -1}
+}
+
+func (f *fakeQueueSender) SendToQueue(_ context.Context, body []byte) error {
+	idx := f.gotCalls
+	f.gotCalls++
+	if idx == f.failAt {
+		return errors.New("fake: send boom")
+	}
+	// Copy the bytes — the caller may reuse the slice.
+	cp := make([]byte, len(body))
+	copy(cp, body)
+	f.bodies = append(f.bodies, cp)
+	return nil
+}
+
+func validRequest() DeleteRequest {
+	return DeleteRequest{
+		PackageID:      123,
+		OrganizationID: 5,
+		UserNodeID:     "N:user:00000000-0000-0000-0000-000000000001",
+		TraceID:        "trace-abc",
+	}
+}
+
+// TestDeletePackages_EnvelopeShape checks the JSON we send: the keys,
+// the types, and the {"DeletePackageJob": {...}} wrapper. If anyone
+// renames a field or changes the shape, this fails.
+func TestDeletePackages_EnvelopeShape(t *testing.T) {
+	p := newFakeQueueSender()
+	err := DeletePackages(context.Background(), p, []DeleteRequest{validRequest()})
+	require.NoError(t, err)
+	require.Len(t, p.bodies, 1)
+
+	// Decode into a map so we check the JSON shape directly rather than
+	// trusting our own Go struct.
+	var outer map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(p.bodies[0], &outer))
+	require.Contains(t, outer, "DeletePackageJob",
+		"payload must be wrapped under DeletePackageJob")
+	require.Len(t, outer, 1, "envelope must have exactly one top-level key")
+
+	var inner map[string]any
+	require.NoError(t, json.Unmarshal(outer["DeletePackageJob"], &inner))
+
+	// Field names + casing.
+	for _, k := range []string{"packageId", "organizationId", "userId", "traceId", "id"} {
+		assert.Contains(t, inner, k, "missing field %q", k)
+	}
+	assert.Len(t, inner, 5, "extra/missing fields: %v", inner)
+
+	// Types. JSON numbers decode to float64 in map[string]any.
+	assert.IsType(t, float64(0), inner["packageId"])
+	assert.IsType(t, float64(0), inner["organizationId"])
+	assert.IsType(t, "", inner["userId"])
+	assert.IsType(t, "", inner["traceId"])
+	assert.IsType(t, "", inner["id"])
+
+	// Values come from the request.
+	assert.EqualValues(t, 123, inner["packageId"])
+	assert.EqualValues(t, 5, inner["organizationId"])
+	assert.Equal(t, "N:user:00000000-0000-0000-0000-000000000001", inner["userId"])
+	assert.Equal(t, "trace-abc", inner["traceId"])
+
+	// id is a fresh UUID.
+	idStr, _ := inner["id"].(string)
+	_, err = uuid.Parse(idStr)
+	assert.NoError(t, err, "id must be a valid UUID, got %q", idStr)
+}
+
+// TestDeletePackages_SendsEach checks that each request results in one
+// SendToQueue call, with a unique id per message.
+func TestDeletePackages_SendsEach(t *testing.T) {
+	p := newFakeQueueSender()
+	reqs := []DeleteRequest{
+		{PackageID: 1, OrganizationID: 5, UserNodeID: "N:user:a", TraceID: "t"},
+		{PackageID: 2, OrganizationID: 5, UserNodeID: "N:user:a", TraceID: "t"},
+		{PackageID: 3, OrganizationID: 5, UserNodeID: "N:user:a", TraceID: "t"},
+	}
+	require.NoError(t, DeletePackages(context.Background(), p, reqs))
+	require.Len(t, p.bodies, 3)
+
+	ids := map[string]struct{}{}
+	for _, b := range p.bodies {
+		var msg map[string]wireMessage
+		require.NoError(t, json.Unmarshal(b, &msg))
+		ids[msg["DeletePackageJob"].Id] = struct{}{}
+	}
+	assert.Len(t, ids, 3, "each message should get a distinct id")
+}
+
+func TestDeletePackages_NilQueueSender(t *testing.T) {
+	err := DeletePackages(context.Background(), nil, []DeleteRequest{validRequest()})
+	assert.Error(t, err)
+}
+
+func TestDeletePackages_EmptySlice(t *testing.T) {
+	p := newFakeQueueSender()
+	assert.NoError(t, DeletePackages(context.Background(), p, nil))
+	assert.Empty(t, p.bodies)
+}
+
+// TestDeletePackages_ContinuesPastSendError checks that one bad send
+// doesn't stop the rest of the batch.
+func TestDeletePackages_ContinuesPastSendError(t *testing.T) {
+	p := newFakeQueueSender()
+	p.failAt = 0 // first call fails
+	reqs := []DeleteRequest{
+		{PackageID: 1, OrganizationID: 5, UserNodeID: "N:user:a", TraceID: "t"},
+		{PackageID: 2, OrganizationID: 5, UserNodeID: "N:user:a", TraceID: "t"},
+	}
+	err := DeletePackages(context.Background(), p, reqs)
+	assert.Error(t, err, "first send error should be returned")
+	assert.Len(t, p.bodies, 1, "second request should still have been sent")
+}
+
+// TestDeletePackages_ValidationFailsPerRequest checks that an invalid
+// request is reported but doesn't block the valid ones around it.
+func TestDeletePackages_ValidationFailsPerRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		mod  func(*DeleteRequest)
+	}{
+		{"zero PackageID", func(r *DeleteRequest) { r.PackageID = 0 }},
+		{"negative PackageID", func(r *DeleteRequest) { r.PackageID = -1 }},
+		{"zero OrganizationID", func(r *DeleteRequest) { r.OrganizationID = 0 }},
+		{"empty UserNodeID", func(r *DeleteRequest) { r.UserNodeID = "" }},
+		{"empty TraceID", func(r *DeleteRequest) { r.TraceID = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bad := validRequest()
+			tt.mod(&bad)
+			good := validRequest()
+			good.PackageID = 999
+
+			p := newFakeQueueSender()
+			err := DeletePackages(context.Background(), p, []DeleteRequest{bad, good})
+			assert.Error(t, err, "the bad request should return an error")
+			assert.Len(t, p.bodies, 1, "the good request should still be sent")
+
+			var msg map[string]wireMessage
+			require.NoError(t, json.Unmarshal(p.bodies[0], &msg))
+			assert.Equal(t, int64(999), msg["DeletePackageJob"].PackageID,
+				"the sent message should be the valid request")
+		})
+	}
+}
+
+// TestDeletePackages_GoldenEnvelope pins the JSON shape with a fixed
+// fixture. The id is generated per message, so we drop it before
+// comparing.
+func TestDeletePackages_GoldenEnvelope(t *testing.T) {
+	p := newFakeQueueSender()
+	require.NoError(t, DeletePackages(context.Background(), p, []DeleteRequest{{
+		PackageID:      42,
+		OrganizationID: 7,
+		UserNodeID:     "N:user:abc",
+		TraceID:        "trace-xyz",
+	}}))
+	require.Len(t, p.bodies, 1)
+
+	var got map[string]map[string]any
+	require.NoError(t, json.Unmarshal(p.bodies[0], &got))
+	delete(got["DeletePackageJob"], "id")
+
+	want := map[string]map[string]any{
+		"DeletePackageJob": {
+			"packageId":      float64(42),
+			"organizationId": float64(7),
+			"userId":         "N:user:abc",
+			"traceId":        "trace-xyz",
+		},
+	}
+	assert.Equal(t, want, got)
+}

--- a/pkg/packagedelete/doc.go
+++ b/pkg/packagedelete/doc.go
@@ -1,0 +1,15 @@
+// Package packagedelete lets Go services ask process-jobs-service to
+// delete a package. It builds the message and hands it off
+//
+// How to use it:
+//
+//   - Plain delete: build a []DeleteRequest and call DeletePackages.
+//
+//   - Replace flow (a new file is taking over an existing name): first
+//     call pgdb.Queries.PrepareReplace inside your transaction. That
+//     renames the old row and marks it as deleting, which frees the name
+//     so your new insert can use it. After you commit, call
+//     DeletePackages to enqueue the actual delete.
+//
+// Note: pennsieve-api sends the same message to the same queue
+package packagedelete

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -252,6 +252,49 @@ func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, record
 	return inserted, nil
 }
 
+// PrepareReplace frees the name in the packages table so an insert for
+// a new file with the same name can claim it. For each predecessor it
+// renames the row to "__DELETED__<NodeId>_<oldName>" and sets state =
+// DELETING.
+//
+// PrepareReplace handles only this "make room" step. After calling it
+// the caller still needs to:
+//   - INSERT the new package with replaces_package_id pointing at the
+//     predecessor's id, and
+//   - UPDATE the predecessor's replaced_by_package_id to point at the
+//     new package once it exists.
+//
+// Run this inside the same transaction as those inserts and updates
+// (use Queries.WithTx). The full replace looks like:
+// PrepareReplace → insert new → set back-reference → commit. Then call
+// packagedelete.DeletePackages to hand off storage/S3/restore-record
+// cleanup to process-jobs-service.
+//
+// Each predecessor needs Id, NodeId, and Name set;
+// findConflictingPackages already returns those.
+func (q *Queries) PrepareReplace(ctx context.Context, predecessors []*pgdb.Package) error {
+	if len(predecessors) == 0 {
+		return nil
+	}
+	for _, p := range predecessors {
+		if p == nil {
+			return errors.New("PrepareReplace: nil predecessor")
+		}
+		if p.Id == 0 || p.NodeId == "" {
+			return fmt.Errorf("PrepareReplace: predecessor missing Id or NodeId (id=%d, nodeId=%q)", p.Id, p.NodeId)
+		}
+		// Same rename pattern addPackagesReplace uses, so both entry
+		// points produce identical __DELETED__ rows.
+		newName := fmt.Sprintf("__DELETED__%s_%s", p.NodeId, p.Name)
+		if _, err := q.db.ExecContext(ctx,
+			"UPDATE packages SET state=$1, name=$2 WHERE id=$3",
+			packageState.Deleting.String(), newName, p.Id); err != nil {
+			return fmt.Errorf("PrepareReplace: renaming predecessor %d: %w", p.Id, err)
+		}
+	}
+	return nil
+}
+
 // findConflictingPackages returns existing, non-deleted packages under the
 // given parent whose name matches any of the incoming records.
 func (q *Queries) findConflictingPackages(ctx context.Context, parentId int64, records []pgdb.PackageParams) (map[string]*pgdb.Package, error) {

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -175,12 +175,7 @@ func (q *Queries) addPackagesKeepBoth(ctx context.Context, parentId int64, recor
 	return allInsertedPackages, nil
 }
 
-// addPackagesReplace soft-deletes each conflicting predecessor, decrements
-// its storage counts, inserts the new packages with replaces_package_id set,
-// then writes the back-reference. Async S3 asset cleanup is the caller's
-// responsibility (publish a DeletePackageJob to the jobs queue for each
-// returned package with ReplacesPackageId set).
-// Caller must ensure the call runs in a transaction for atomicity.
+// addPackagesReplace clears each conflicting name (via PrepareReplace)
 func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, records []pgdb.PackageParams) ([]pgdb.Package, error) {
 	conflicts, err := q.findConflictingPackages(ctx, parentId, records)
 	if err != nil {
@@ -188,44 +183,19 @@ func (q *Queries) addPackagesReplace(ctx context.Context, parentId int64, record
 	}
 
 	replacementByNodeId := map[string]int64{}
+	predecessors := make([]*pgdb.Package, 0, len(conflicts))
 	for _, r := range records {
 		if old, ok := conflicts[r.Name]; ok {
 			replacementByNodeId[r.NodeId] = old.Id
 		}
 	}
-
-	datasetId := int64(records[0].DatasetId)
-
-	// Rename + soft-delete each predecessor so the new insert doesn't trip
-	// the unique (name, dataset_id, parent_id) partial indexes, and decrement
-	// its storage so dataset/ancestor counts reflect the removal. Mirrors
-	// pennsieve-api's PackageManager.delete behavior on the DB side.
 	for _, old := range conflicts {
-		newName := fmt.Sprintf("__DELETED__%s_%s", old.NodeId, old.Name)
-		_, err := q.db.ExecContext(ctx,
-			"UPDATE packages SET state=$1, name=$2 WHERE id=$3",
-			packageState.Deleting.String(), newName, old.Id)
-		if err != nil {
-			return nil, fmt.Errorf("soft-deleting predecessor %d: %w", old.Id, err)
-		}
+		predecessors = append(predecessors, old)
+	}
 
-		size, err := q.GetPackageStorageById(ctx, old.Id)
-		if err != nil {
-			// No storage row just means no decrement needed.
-			if errors.Is(err, sql.ErrNoRows) {
-				continue
-			}
-			return nil, fmt.Errorf("reading storage for predecessor %d: %w", old.Id, err)
-		}
-		if size <= 0 {
-			continue
-		}
-		if err := q.IncrementPackageStorageAncestors(ctx, old.Id, -size); err != nil {
-			return nil, fmt.Errorf("decrementing package/ancestor storage for predecessor %d: %w", old.Id, err)
-		}
-		if err := q.IncrementDatasetStorage(ctx, datasetId, -size); err != nil {
-			return nil, fmt.Errorf("decrementing dataset storage for predecessor %d: %w", old.Id, err)
-		}
+	// Free the name slot for each predecessor (rename + state=DELETING)
+	if err := q.PrepareReplace(ctx, predecessors); err != nil {
+		return nil, err
 	}
 
 	inserted, failed, err := q.addPackageByParent(ctx, parentId, records, replacementByNodeId)

--- a/pkg/queries/pgdb/packages.go
+++ b/pkg/queries/pgdb/packages.go
@@ -286,10 +286,22 @@ func (q *Queries) PrepareReplace(ctx context.Context, predecessors []*pgdb.Packa
 		// Same rename pattern addPackagesReplace uses, so both entry
 		// points produce identical __DELETED__ rows.
 		newName := fmt.Sprintf("__DELETED__%s_%s", p.NodeId, p.Name)
-		if _, err := q.db.ExecContext(ctx,
+		result, err := q.db.ExecContext(ctx,
 			"UPDATE packages SET state=$1, name=$2 WHERE id=$3",
-			packageState.Deleting.String(), newName, p.Id); err != nil {
+			packageState.Deleting.String(), newName, p.Id)
+		if err != nil {
 			return fmt.Errorf("PrepareReplace: renaming predecessor %d: %w", p.Id, err)
+		}
+		// No matching row means the caller handed us a bad or stale id.
+		// Fail loudly rather than report success — otherwise the caller
+		// goes on to insert a new package pointing at a row that isn't
+		// where it thinks it is.
+		n, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("PrepareReplace: checking rows affected for %d: %w", p.Id, err)
+		}
+		if n == 0 {
+			return fmt.Errorf("PrepareReplace: predecessor %d not found (or already deleting)", p.Id)
 		}
 	}
 	return nil

--- a/pkg/queries/pgdb/packages_test.go
+++ b/pkg/queries/pgdb/packages_test.go
@@ -29,6 +29,9 @@ func TestPackageTable(t *testing.T) {
 		"Test getting ancestor Ids":      testGettingAncestors,
 		"Test conflict replace":          testConflictReplace,
 		"Test conflict replace no-op":    testConflictReplaceNoConflict,
+		"Test PrepareReplace":            testPrepareReplace,
+		"Test PrepareReplace empty":      testPrepareReplaceEmpty,
+		"Test PrepareReplace validation": testPrepareReplaceValidation,
 	} {
 		t.Run(scenario, func(t *testing.T) {
 			orgId := 1
@@ -692,4 +695,102 @@ func testConflictReplaceNoConflict(t *testing.T, store *SQLStore, orgId int) {
 	assert.Equal(t, "solo.txt", result[0].Name)
 	assert.False(t, result[0].ReplacesPackageId.Valid, "No conflict = no replaces_package_id")
 	assert.False(t, result[0].ReplacedByPackageId.Valid, "Fresh insert should have null replaced_by_package_id")
+}
+
+// testPrepareReplace checks that PrepareReplace renames the old row and
+// sets it to DELETING — and nothing else. Storage rows should stay put;
+// the delete consumer handles those.
+func testPrepareReplace(t *testing.T, store *SQLStore, orgId int) {
+	defer test.Truncate(t, store.db, orgId, "packages")
+	defer test.Truncate(t, store.db, orgId, "package_storage")
+	defer test.Truncate(t, store.db, orgId, "dataset_storage")
+
+	datasetId := int64(1)
+	ctx := context.Background()
+
+	// Seed two packages so we can confirm only the target one moves.
+	seed := test.GenerateTestPackages([]test.PackageParams{
+		{Name: "report.csv", ParentId: -1},
+		{Name: "untouched.csv", ParentId: -1},
+	}, int(datasetId))
+	inserted, err := store.AddPackagesWithConflict(ctx, seed, conflictStrategy.KeepBoth)
+	assert.NoError(t, err)
+	assert.Len(t, inserted, 2)
+
+	var target, bystander pgdb.Package
+	for i := range inserted {
+		switch inserted[i].Name {
+		case "report.csv":
+			target = inserted[i]
+		case "untouched.csv":
+			bystander = inserted[i]
+		}
+	}
+	originalName := target.Name
+	originalNodeId := target.NodeId
+
+	// Add storage rows on the target so we can verify PrepareReplace leaves
+	// them alone.
+	const targetStorage = int64(1000)
+	assert.NoError(t, store.Queries.IncrementPackageStorage(ctx, target.Id, targetStorage))
+	assert.NoError(t, store.Queries.IncrementDatasetStorage(ctx, datasetId, targetStorage))
+
+	// Run it.
+	err = store.Queries.PrepareReplace(ctx, []*pgdb.Package{&target})
+	assert.NoError(t, err)
+
+	// The target row should be renamed and set to DELETING.
+	selectStmt := fmt.Sprintf(
+		"SELECT name, state FROM \"%d\".packages WHERE id=$1", orgId)
+	var gotName, gotState string
+	assert.NoError(t, store.db.QueryRow(selectStmt, target.Id).Scan(&gotName, &gotState))
+	assert.Equal(t, packageState.Deleting.String(), gotState,
+		"state should be DELETING")
+	assert.Equal(t, fmt.Sprintf("__DELETED__%s_%s", originalNodeId, originalName), gotName,
+		"row should be renamed with __DELETED__ prefix")
+
+	// Storage should not have moved.
+	pkgStorage, err := store.Queries.GetPackageStorageById(ctx, target.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, targetStorage, pkgStorage,
+		"package storage should not change")
+	dsStorage, err := store.Queries.GetDatasetStorageById(ctx, datasetId)
+	assert.NoError(t, err)
+	assert.Equal(t, targetStorage, dsStorage,
+		"dataset storage should not change")
+
+	// The other package should not move.
+	var bystanderName, bystanderState string
+	assert.NoError(t, store.db.QueryRow(selectStmt, bystander.Id).Scan(&bystanderName, &bystanderState))
+	assert.Equal(t, "untouched.csv", bystanderName)
+	assert.NotEqual(t, packageState.Deleting.String(), bystanderState)
+
+	// The name slot should be free: re-inserting the same name in the
+	// same parent should succeed and keep the original name.
+	reinsert := test.GenerateTestPackages([]test.PackageParams{
+		{Name: originalName, ParentId: -1},
+	}, int(datasetId))
+	reResult, err := store.AddPackagesWithConflict(ctx, reinsert, conflictStrategy.KeepBoth)
+	assert.NoError(t, err, "name should be free after PrepareReplace")
+	assert.Len(t, reResult, 1)
+	assert.Equal(t, originalName, reResult[0].Name,
+		"new insert should claim the original name (no auto-rename)")
+}
+
+// testPrepareReplaceEmpty: nil or empty input is a no-op, not an error.
+func testPrepareReplaceEmpty(t *testing.T, store *SQLStore, _ int) {
+	assert.NoError(t, store.Queries.PrepareReplace(context.Background(), nil))
+	assert.NoError(t, store.Queries.PrepareReplace(context.Background(), []*pgdb.Package{}))
+}
+
+// testPrepareReplaceValidation: bad input should error early rather than
+// run a SQL update that matches nothing or writes a malformed name.
+func testPrepareReplaceValidation(t *testing.T, store *SQLStore, _ int) {
+	ctx := context.Background()
+	assert.Error(t, store.Queries.PrepareReplace(ctx, []*pgdb.Package{nil}),
+		"nil predecessor entry must error")
+	assert.Error(t, store.Queries.PrepareReplace(ctx, []*pgdb.Package{{Id: 0, NodeId: "N:package:x", Name: "x"}}),
+		"zero Id must error")
+	assert.Error(t, store.Queries.PrepareReplace(ctx, []*pgdb.Package{{Id: 1, NodeId: "", Name: "x"}}),
+		"empty NodeId must error")
 }

--- a/pkg/queries/pgdb/packages_test.go
+++ b/pkg/queries/pgdb/packages_test.go
@@ -793,4 +793,9 @@ func testPrepareReplaceValidation(t *testing.T, store *SQLStore, _ int) {
 		"zero Id must error")
 	assert.Error(t, store.Queries.PrepareReplace(ctx, []*pgdb.Package{{Id: 1, NodeId: "", Name: "x"}}),
 		"empty NodeId must error")
+	// Well-formed input, but the id doesn't exist in the table — the
+	// UPDATE matches nothing, so PrepareReplace should fail rather than
+	// quietly report success.
+	assert.Error(t, store.Queries.PrepareReplace(ctx, []*pgdb.Package{{Id: 999999, NodeId: "N:package:missing", Name: "ghost.csv"}}),
+		"unknown id must error")
 }

--- a/pkg/queries/pgdb/packages_test.go
+++ b/pkg/queries/pgdb/packages_test.go
@@ -619,10 +619,10 @@ func testGettingAncestors(t *testing.T, store *SQLStore, orgId int) {
 }
 
 // testConflictReplace verifies the Replace strategy soft-deletes the
-// predecessor, inserts the new package with the back-reference populated,
-// sets replaced_by_package_id on the predecessor, and decrements the
-// predecessor's storage counts (package + dataset) to match
-// pennsieve-api's PackageManager.delete behavior.
+// predecessor (rename + DELETING), inserts the new package with the
+// back-reference populated, and sets replaced_by_package_id on the
+// predecessor. Storage counts are left alone — process-jobs-service
+// decrements them when it handles the delete job.
 func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
 	defer test.Truncate(t, store.db, orgId, "packages")
 	defer test.Truncate(t, store.db, orgId, "package_storage")
@@ -639,7 +639,7 @@ func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
 	assert.Len(t, originalResult, 1)
 	originalId := originalResult[0].Id
 
-	// Seed storage rows so we can verify decrement.
+	// Seed storage rows so we can verify Replace leaves them alone.
 	const predecessorSize = int64(1000)
 	assert.NoError(t, store.Queries.IncrementPackageStorage(context.Background(), originalId, predecessorSize))
 	assert.NoError(t, store.Queries.IncrementDatasetStorage(context.Background(), datasetId, predecessorSize))
@@ -671,14 +671,15 @@ func testConflictReplace(t *testing.T, store *SQLStore, orgId int) {
 	assert.True(t, predecessorReplacedBy.Valid, "replaced_by_package_id should be set")
 	assert.Equal(t, newPkg.Id, predecessorReplacedBy.Int64, "Predecessor's replaced_by_package_id should point at the new row")
 
-	// Storage counts on the predecessor and dataset should be decremented to 0.
+	// Storage counts should be untouched — the delete consumer decrements
+	// them, not the replace insert.
 	predecessorStorage, err := store.Queries.GetPackageStorageById(context.Background(), originalId)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(0), predecessorStorage, "Predecessor package_storage should decrement to 0")
+	assert.Equal(t, predecessorSize, predecessorStorage, "Predecessor package_storage should be unchanged")
 
 	datasetStorage, err := store.Queries.GetDatasetStorageById(context.Background(), datasetId)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(0), datasetStorage, "Dataset storage should decrement to 0")
+	assert.Equal(t, predecessorSize, datasetStorage, "Dataset storage should be unchanged")
 }
 
 // testConflictReplaceNoConflict verifies the Replace strategy inserts


### PR DESCRIPTION
- New pkg/packagedelete: used to ask process-jobs-service to delete a package.
- New Queries.PrepareReplace: rename the old row and set it to DELETING so a new file can reuse the name
- addPackagesReplace slimmed down:  now calls PrepareReplace for the rename and no longer decrements storage. Storage cleanup (plus deleting the S3 file and writing the restore record) will happen in process-jobs-service
- Unit tests

No changes in platform behaviour until upload-service-v2 switches over to use this (coming in a next PR)