### PR TITLE
Update check for file extensions

### DIFF
--- a/pkg/models/fileInfo/fileType/models.go
+++ b/pkg/models/fileInfo/fileType/models.go
@@ -471,7 +471,7 @@ var ExtensionToTypeDict = map[string]Type{
 	"nex":           NeuroExplorer,
 	"nex5":          NeuroExplorer,
 	"smr":           Spike2,
-	".eeg":          NihonKoden,
+	"eeg":           NihonKoden,
 	"plx":           Plexon,
 	"pl2":           Plexon,
 	"e":             Nicolet,

--- a/pkg/upload/package.go
+++ b/pkg/upload/package.go
@@ -33,16 +33,9 @@ func resolveTypeFromName(targetName string) fileType.Type {
 	var bestKey string
 	bestLen := -1
 	for ext := range fileType.ExtensionToTypeDict {
-		// Most keys are stored without a leading dot ("edf", "nii.gz")
-		// But a few keep the leading `.` (e.g. ".eeg")
-		// Normalize by trimming any leading dots.
-		trimmedExt := strings.TrimPrefix(ext, ".")
-		if trimmedExt == "" {
-			continue
-		}
 		// longer matches are always the right choice (ie choose ".nii.gz" over ".gz")
-		if len(trimmedExt) > bestLen && strings.HasSuffix(lowerTargetName, "."+trimmedExt) {
-			bestLen = len(trimmedExt)
+		if len(ext) > bestLen && strings.HasSuffix(lowerTargetName, "."+ext) {
+			bestLen = len(ext)
 			bestKey = ext
 		}
 	}

--- a/pkg/upload/package.go
+++ b/pkg/upload/package.go
@@ -1,52 +1,58 @@
 package upload
 
 import (
+	"strings"
+
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/fileInfo/fileType"
 	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
 	log "github.com/sirupsen/logrus"
-	"regexp"
-	"strings"
 )
 
 func PackageTypeResolver(items []manifestFile.FileDTO) []manifestFile.FileDTO {
 
-	for i, f := range items {
+	for i := range items {
 
-		// Determine Type based on extension, or
-		// return type that is already defined in FileDTO
-		var fileExtension string
-		var fType fileType.Type
+		// Only resolve the type from the file name when one hasn't already
+		// been set on the FileDTO; an existing FileType is left untouched.
 		if len(items[i].FileType) == 0 {
-			// 1. Find FileType
-
-			// Split on the first '.' and consider everything after the extension.
-			r := regexp.MustCompile(`(?P<FileName>[^\.]*)?\.?(?P<Extension>.*)`)
-			pathParts := r.FindStringSubmatch(f.TargetName)
-			if pathParts == nil {
-				log.WithFields(
-					log.Fields{
-						"upload_id": items[i].UploadID,
-					},
-				).Error("Unable to parse filename:", f.TargetName)
-				continue
-			}
-
-			fileExtension = pathParts[r.SubexpIndex("Extension")]
-
-			var exists bool
-			fType, exists = fileType.ExtensionToTypeDict[fileExtension]
-			if !exists {
-				fType = fileType.GenericData
-			}
-
-			// Set the type if not previously set.
+			fType := resolveTypeFromName(items[i].TargetName)
 			items[i].FileType = fType.String()
-		} else {
-			fType = fileType.Dict[items[i].FileType]
 		}
-
 	}
 	return items
+}
+
+// resolveTypeFromName determines a file's fileType.Type from its name by
+// matching against the longest known extension in ExtensionToTypeDict.
+// It uses a longest-suffix match rather than splitting on the first '.' so that
+// names with extra dots (e.g. "example.june_21.edf") and multi-part extensions
+// (e.g. "scan.nii.gz", "image.ome.tiff") both resolve correctly. Case-insensitive.
+func resolveTypeFromName(targetName string) fileType.Type {
+	lowerTargetName := strings.ToLower(targetName)
+
+	var bestKey string
+	bestLen := -1
+	for ext := range fileType.ExtensionToTypeDict {
+		// Most keys are stored without a leading dot ("edf", "nii.gz")
+		// But a few keep the leading `.` (e.g. ".eeg")
+		// Normalize by trimming any leading dots.
+		trimmedExt := strings.TrimPrefix(ext, ".")
+		if trimmedExt == "" {
+			continue
+		}
+		// longer matches are always the right choice (ie choose ".nii.gz" over ".gz")
+		if len(trimmedExt) > bestLen && strings.HasSuffix(lowerTargetName, "."+trimmedExt) {
+			bestLen = len(trimmedExt)
+			bestKey = ext
+		}
+	}
+
+	if bestKey == "" {
+		log.WithFields(log.Fields{"targetName": targetName}).
+			Debug("no known file extension matched; defaulting to GenericData")
+		return fileType.GenericData
+	}
+	return fileType.ExtensionToTypeDict[bestKey]
 }
 
 func persystMerger(fileName string, layFile *manifestFile.FileDTO, items []manifestFile.FileDTO) {

--- a/pkg/upload/package_test.go
+++ b/pkg/upload/package_test.go
@@ -86,3 +86,70 @@ func testBasicExtensions(t *testing.T, files []manifestFile.FileDTO) {
 	assert.Equal(t, "GenericData", files[5].FileType,
 		"Unknown extensions should return 'Generic Data' type.")
 }
+
+// TestPackageTypeResolverExtensions exercises the longest-suffix extension
+// matching, with emphasis on the cases the old first-dot split got wrong:
+// names with extra dots before the extension, and multi-part extensions.
+func TestPackageTypeResolverExtensions(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetName   string
+		expectedType string
+	}{
+		// Single-part extensions
+		{"single dot", "example.edf", "EDF"},
+		{"extra dots before single-part ext (the bug)", "example.june_21.edf", "EDF"},
+		{"many extra dots", "a.b.c.d.edf", "EDF"},
+
+		// Multi-part extensions
+		{"multi-part nii.gz", "scan.nii.gz", "NIFTI"},
+		{"multi-part with extra dots", "subject.2024.session1.nii.gz", "NIFTI"},
+		{"multi-part ome.tiff", "image.ome.tiff", "OMETIFF"},
+
+		// Longest-suffix precedence: nii.gz/tar.gz must win over bare gz
+		{"longest match nii.gz beats gz", "brain.nii.gz", "NIFTI"},
+		{"longest match tar.gz beats gz", "archive.tar.gz", "ZIP"},
+		{"bare gz still resolves", "data.gz", "ZIP"},
+
+		// Leading-dot dict key (".eeg") still matches via normalization
+		{"leading-dot dict key eeg", "recording.eeg", "NihonKoden"},
+
+		// Case-insensitivity
+		{"uppercase single", "EXAMPLE.EDF", "EDF"},
+		{"mixed-case multi-part", "Scan.NII.GZ", "NIFTI"},
+
+		// Non-matches default to GenericData
+		{"unknown extension", "notes.xyz", "GenericData"},
+		{"no extension", "README", "GenericData"},
+		{"dotfile, no known ext", ".bashrc", "GenericData"},
+		{"name equals ext but no dot", "edf", "GenericData"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := []manifestFile.FileDTO{{
+				UploadID:   "0",
+				TargetPath: "path",
+				TargetName: tt.targetName,
+				FileType:   "",
+			}}
+			result := PackageTypeResolver(files)
+			assert.Equal(t, tt.expectedType, result[0].FileType,
+				"file %q should resolve to %s", tt.targetName, tt.expectedType)
+		})
+	}
+}
+
+// TestPackageTypeResolverPreservesExistingType ensures a FileType that is
+// already set is never overwritten, even when the name would resolve elsewhere.
+func TestPackageTypeResolverPreservesExistingType(t *testing.T) {
+	files := []manifestFile.FileDTO{{
+		UploadID:   "0",
+		TargetPath: "path",
+		TargetName: "example.june_21.edf",
+		FileType:   "DICOM",
+	}}
+	result := PackageTypeResolver(files)
+	assert.Equal(t, "DICOM", result[0].FileType,
+		"an already-set FileType must not be overwritten")
+}


### PR DESCRIPTION
File extension checks could mess up when a a file used a period as part of it's name. IE `example.june_23.edf` would read the extension as `june_23.edf`, causing downstream issues that depend on having the right file type.